### PR TITLE
Improve Recipe

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.4
     hooks:

--- a/.vscode-ext/README.md
+++ b/.vscode-ext/README.md
@@ -1,0 +1,22 @@
+# TMT recipe file
+
+A vibe coded VSCode extension for TMT recipe syntax highlighting.
+
+## Installation
+
+### Option 1: GUI (Recommended)
+
+1. Press `Cmd+Shift+P` (Mac) / `Ctrl+Shift+P` (Windows/Linux)
+2. Type "Developer: Install Extension from Location"
+3. Select the `.vscode-ext` folder
+
+### Option 2: CLI
+
+```bash
+code --install-extension .vscode-ext
+```
+
+## Supported Files
+
+- Files named `recipe`
+- Files with extension `.recipe`

--- a/.vscode-ext/icons/recipe.svg
+++ b/.vscode-ext/icons/recipe.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <!-- https://github.com/microsoft/vscode/issues/178986 -->
+  <g transform="translate(4, 0)">
+    <path transform="translate(5.0000,20.0247) scale(0.005967,-0.005967)"
+          d="M762 1121V0H467V1121H61V1349H1168V1121Z"
+          fill="#9F74B3"/>
+    <path transform="translate(12.3333,20.0247) scale(0.005967,-0.005967)"
+          d="M908 0V868Q908 973 924 1169Q865 879 849 828L725 360H507L381 828Q352 936 305 1169L312 1069Q319 964 319 868V0H99V1349H446L581 850Q596 803 619 619Q639 774 659 849L795 1349H1130V0Z"
+          fill="#9F74B3"/>
+    <path transform="translate(19.6667,20.0247) scale(0.005967,-0.005967)"
+          d="M762 1121V0H467V1121H61V1349H1168V1121Z"
+          fill="#9F74B3"/>
+  </g>
+</svg>

--- a/.vscode-ext/package.json
+++ b/.vscode-ext/package.json
@@ -1,0 +1,41 @@
+{
+    "name": "tmt-recipe",
+    "displayName": "TMT recipe file",
+    "description": "Syntax highlighting for recipe files",
+    "version": "0.0.1",
+    "publisher": "local",
+    "engines": {
+        "vscode": "^1.0.0"
+    },
+    "categories": [
+        "Programming Languages"
+    ],
+    "contributes": {
+        "languages": [
+            {
+                "id": "recipe",
+                "aliases": [
+                    "TMT recipe file",
+                    "recipe"
+                ],
+                "extensions": [
+                    ".recipe"
+                ],
+                "filenamePatterns": [
+                    "**/recipe"
+                ],
+                "icon": {
+                    "dark": "./icons/recipe.svg",
+                    "light": "./icons/recipe.svg"
+                }
+            }
+        ],
+        "grammars": [
+            {
+                "language": "recipe",
+                "scopeName": "source.recipe",
+                "path": "./syntaxes/recipe.tmLanguage.json"
+            }
+        ]
+    }
+}

--- a/.vscode-ext/syntaxes/recipe.tmLanguage.json
+++ b/.vscode-ext/syntaxes/recipe.tmLanguage.json
@@ -1,0 +1,62 @@
+{
+    "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+    "name": "recipe",
+    "patterns": [
+        {
+            "include": "#comment"
+        },
+        {
+            "include": "#keyword"
+        },
+        {
+            "include": "#generator_name"
+        },
+        {
+            "include": "#pipe"
+        },
+        {
+            "include": "#variable"
+        },
+        {
+            "include": "#string"
+        },
+        {
+            "include": "#number"
+        }
+    ],
+    "repository": {
+        "comment": {
+            "match": "#.*$",
+            "name": "comment.line.number-sign.recipe"
+        },
+        "keyword": {
+            "match": "@\\w+",
+            "name": "keyword.control.recipe"
+        },
+        "generator_name": {
+            "match": "(?:^|\\|)\\s*(\\w+)",
+            "captures": {
+                "1": {
+                    "name": "entity.name.function.recipe"
+                }
+            }
+        },
+        "pipe": {
+            "match": "\\|",
+            "name": "keyword.operator.pipe.recipe"
+        },
+        "variable": {
+            "match": "\\$\\{?\\w+\\}?",
+            "name": "variable.other.recipe"
+        },
+        "string": {
+            "match": "\"[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*\"|'[^'\\\\]*(?:\\\\.[^'\\\\]*)*'",
+            "name": "string.quoted.recipe"
+        },
+        "number": {
+            "match": "\\b\\d+\\b",
+            "name": "constant.numeric.recipe"
+        }
+    },
+    "scopeName": "source.recipe"
+}

--- a/.vscode-ext/syntaxes/recipe.tmLanguage.json
+++ b/.vscode-ext/syntaxes/recipe.tmLanguage.json
@@ -2,60 +2,144 @@
     "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
     "name": "recipe",
     "patterns": [
-        {
-            "include": "#comment"
-        },
-        {
-            "include": "#keyword"
-        },
-        {
-            "include": "#generator_name"
-        },
-        {
-            "include": "#pipe"
-        },
-        {
-            "include": "#variable"
-        },
-        {
-            "include": "#string"
-        },
-        {
-            "include": "#number"
-        }
+        { "include": "#comment" },
+        { "include": "#keywords" },
+        { "include": "#invalid-pipe" },
+        { "include": "#generation" }
     ],
     "repository": {
         "comment": {
-            "match": "#.*$",
+            "match": "#.*(?=$)",
             "name": "comment.line.number-sign.recipe"
         },
-        "keyword": {
-            "match": "@\\w+",
-            "name": "keyword.control.recipe"
-        },
-        "generator_name": {
-            "match": "(?:^|\\|)\\s*(\\w+)",
-            "captures": {
-                "1": {
-                    "name": "entity.name.function.recipe"
-                }
-            }
-        },
-        "pipe": {
-            "match": "\\|",
-            "name": "keyword.operator.pipe.recipe"
-        },
         "variable": {
-            "match": "\\$\\{?\\w+\\}?",
-            "name": "variable.other.recipe"
+            "match": "\\$\\{\\w+\\}",
+            "name": "variable.other"
         },
-        "string": {
-            "match": "\"[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*\"|'[^'\\\\]*(?:\\\\.[^'\\\\]*)*'",
-            "name": "string.quoted.recipe"
+        "double-quoted-token": {
+            "begin": "\"(?=[^\"]*\"\\s)",
+            "end": "\"\\s+",
+            "name": "string.quoted.double",
+            "patterns": [ { "include": "#variable" } ]
         },
-        "number": {
-            "match": "\\b\\d+\\b",
-            "name": "constant.numeric.recipe"
+        "single-quoted-token": {
+            "begin": "'(?=[^']*'\\s)",
+            "end": "'\\s+",
+            "name": "string.quoted.single",
+            "patterns": [ { "include": "#variable" } ]
+        },
+        "unquoted-token": {
+            "begin": "",
+            "end": "\\s+",
+            "name": "string.unquoted",
+            "patterns": [ { "include": "#variable" } ]
+        },
+        "keywords": {
+            "patterns": [
+                {
+                    "begin": "(@description)\\s++",
+                    "end": "$",
+                    "beginCaptures": { "1": { "name": "keyword.control.description" } },
+                    "name": "string.unquoted",
+                    "patterns": [ { "include": "#variable" } ]
+                },
+                {
+                    "match": "(@testset|@include)\\s+((\"([^\"]*)\")|('([^']*)')|(\\S+))\\s*(?:$|(#.*$))",
+                    "captures": {
+                        "1": { "name": "keyword.control" },
+                        "2": { "name": "meta.argument" },
+                        "3": { "name": "string.quoted.double" },
+                        "4": { "name": "entity.name.tag" },
+                        "5": { "name": "string.quoted.single" },
+                        "6": { "name": "entity.name.tag" },
+                        "7": { "name": "entity.name.tag" },
+                        "8": { "name": "comment.line.number-sign.recipe" }
+                    }
+                },
+                {
+                    "match": "(@subtask)\\s+((\"([^\"]*)\")|('([^']*)')|(\\S+))\\s+(\\d+|\\d*.\\d+)\\s*(?:$|(#.*$))",
+                    "captures": {
+                        "1": { "name": "keyword.control.recipe" },
+                        "2": { "name": "meta.argument" },
+                        "3": { "name": "string.quoted.double" },
+                        "4": { "name": "entity.name.tag" },
+                        "5": { "name": "string.quoted.single" },
+                        "6": { "name": "entity.name.tag" },
+                        "7": { "name": "entity.name.tag" },
+                        "8": { "name": "constant.numeric.recipe" },
+                        "9": { "name": "comment.line.number-sign.recipe" }
+                    }
+                },
+                {
+                    "match": "(@constant)\\s+(\\S+)\\s+((\"[^\"]*\")|('[^']*')|(\\S+))\\s*(?:$|(#.*$))",
+                    "captures": {
+                        "1": { "name": "keyword.control.recipe" },
+                        "2": { "name": "variable.other.recipe" },
+                        "3": { "name": "meta.argument" },
+                        "4": { "name": "string.quoted.double" },
+                        "5": { "name": "string.quoted.single" },
+                        "6": { "name": "string.unquoted" },
+                        "7": { "name": "comment.line.number-sign" }
+                    }
+                },
+                {
+                    "match": "(@extra_file)\\s+(\\S+)\\s+(\\.\\S+)\\s*(?:$|(#.*$))",
+                    "captures": {
+                        "1": { "name": "keyword.control.recipe" },
+                        "2": { "name": "variable.other.recipe" },
+                        "3": { "name": "string.unquoted" },
+                        "4": { "name": "comment.line.number-sign" }
+                    }
+                },
+                {
+                    "begin": "(@global_validation|@validation)\\s+(\"[^\"]*\"|'[^']*'|\\S+)\\s+",
+                    "beginCaptures": {
+                        "1": { "name": "keyword.control" },
+                        "2": { "name": "entity.name.function.recipe" }
+                    },
+                    "end": "$",
+                    "patterns": [
+                        { "include": "#single-quoted-token" },
+                        { "include": "#double-quoted-token" },
+                        {
+                            "match": "\\|\\s+",
+                            "name": "invalid.illegal.validation.pipe"
+                        },
+                        { "include": "#unquoted-token" }
+                    ]
+                },
+                {
+                    "match": "@.*",
+                    "name": "invalid.illegal.keyword.recipe"
+                }
+            ]
+        },
+        "invalid-pipe": {
+            "match": "^\\s*\\|\\s+",
+            "name": "invalid.illegal.starting-pipe"
+        },
+        "generation": {
+            "begin": "(\"[^\"]*\"|'[^']*'|\\S+)\\s+",
+            "end": "$",
+            "name": "entity.name.function.recipe",
+            "patterns": [
+                { "include": "#single-quoted-token" },
+                { "include": "#double-quoted-token" },
+                { "include": "#comment" },
+                {
+                    "match": "\\|\\s+\\|\\s+",
+                    "name": "invalid.illegal.double-pipe"
+                },
+                {
+                    "match": "\\|\\s+(\"[^\"]*\"|'[^']*'|\\S+)\\s+",
+                    "name": "entity.name.function.recipe"
+                },
+                {
+                    "match": "\\|\\s+",
+                    "name": "invalid.illegal.ending-pipe"
+                },
+                { "include": "#unquoted-token" }
+            ]
         }
     },
     "scopeName": "source.recipe"

--- a/docs/recipe.md
+++ b/docs/recipe.md
@@ -1,0 +1,394 @@
+# TMT Recipe Syntax
+
+TMT generates and manages test cases based on the `recipe` file.
+
+- [TMT Recipe Syntax](#tmt-recipe-syntax)
+  - [Characters](#characters)
+  - [Lines](#lines)
+  - [Words](#words)
+    - [Quoting](#quoting)
+    - [Comments](#comments)
+  - [Generation Sequences](#generation-sequences)
+  - [Keywords](#keywords)
+    - [`@testset` and `@subtask`](#testset-and-subtask)
+    - [`@include`](#include)
+    - [`@constant`](#constant)
+    - [`@description`](#description)
+    - [`@validation` and `@global_validation`](#validation-and-global_validation)
+    - [`@extra_file`](#extra_file)
+
+## Characters
+
+In TMT, there are three types of characters:
+
+- Whitespace characters.  
+  They are the [ASCII](https://en.wikipedia.org/wiki/ASCII) whitespaces:
+  - 0x0A new line,
+  - 0x0B vertical tab,
+  - 0x0C form feed,
+  - 0x0D carriage return, and
+  - 0x20 space.
+- Plain characters.  
+  - digits `0-9` (0x30 -- 0x39),
+  - upper case Latin alphabet `A-Z` (0x41 -- 0x5A).
+  - lower case Latin alphabet `a-z` (0x61 -- 0x7A).
+  - Hyphen-minus `-` (0x2D).
+  - Underscore `_` (0x5F).
+- Special characters.  
+    These are the ASCII printable characters, **except** for whitespaces, plain characters, and the below:
+  - ampersand `&` (0x26),
+  - star `*` (0x2A),
+  - forward slash `/` (0x2F),
+  - colon `:` (0x3A),
+  - semicolon `;` (0x3B),
+  - less than `<` (0x3C),
+  - greater than `>` (0x3E),
+  - question mark `?` (0x3F),
+  - backward slash `\` (0x5C), and
+  - backtick <code>`</code> (0x60).
+
+Whitespace, plain, and special characters are collectively called base characters.
+
+
+## Lines
+
+In TMT, each line is considered a single command.
+Each command can be a generation sequence or keyword command.
+
+If a line does not follow the specification, then the line is *ill-formed*.
+Recipes with any ill-formed line are rejected by the tool and diagnostics will be provided for each of those lines.
+
+## Words
+
+Each line in a TMT recipe is parsed into a sequence of words.
+
+For each line, the leading and trailing whitespaces are removed.
+The word sequence is formed by repeatedly extracting valid words from the line by the following process.
+
+1. Remove the leading whitespace characters.
+2. If the line is exhausted, finish the word sequence parsing.
+3. Extract a word according to the [quoting rule](#quoting).
+4. If no word can be extracted, the line is ill-formed.
+5. If the word forms a valid [comment](#comments), the word and the rest of the line is discarded.
+6. If the word is the first in the sequence, is unquoted, and exactly matches `@description`, then the word sequence parsing ends.
+   For this specific case, see keyword [`@description`](#description).
+
+If the sequence is empty, the line is ignored.
+If the first word is unquoted and starts with `@`, it is considered a [keyword command](#keywords); otherwise, it is a [generation sequence](#generation-sequences).
+
+For example,
+```
+@testset group1
+'@testset' group2
+```
+means different things.
+The first one means to use the keyword `@testset` with arguments `group1`, while the second one simply specifies the [command sequence](#command-sequence) `@testset` with arguments `group2` because the first word is quoted, so it no longer refers to the keyword.
+
+
+### Quoting
+
+In TMT, each word can be quoted.
+You can use quoting to enclose any sequence of base characters:
+
+```
+gen "I'm TAS" ''
+```
+will be properly split into three words: `gen`, `I'm TAS`, and an empty word.
+
+In particular, there are three types of words:
+- A string surrounded with double quotes (`"`) and does not contain any double quote is called a *double-quoted* word.
+- A string surrounded with single quotes (`'`) and does not contain any single quote is called a *single-quoted* word.
+- A string not starting with either of the quotes is called a *plain* word.
+
+All words can only contain base characters.
+
+Note that, a word starting with any kind of quote but not closed before the end of the line, is considered ill-formed.
+For example,
+```
+gen "this is not closed...
+```
+is ill-formed.
+
+If a word is quoted, the word represents the content without the surrounding quotation marks.
+Otherwise, the word is treated as-is.
+
+### Comments
+
+TMT recipe file recognizes single line comments.
+An unquoted word starting with the number sign (`#`) comments out the rest of a line:
+```
+gen 8 fixed  # generates the special case when N = 8
+```
+
+
+For example, all of the following forms valid comments:
+```
+gen #
+gen #still a comment
+gen # definitely a valid comment
+```
+However, quoted and words containing `#` in between will **not** be considered as valid comments:
+```
+gen not comment#
+gen '# not comment'
+gen '#' not comment
+```
+are all lines without comments.
+
+## Generation Sequences
+
+Each generation sequence generates one test case.
+Before the generation process, each file recognized by TMT in directory `generator` will be compiled to a generator named by the stem (base name; the part without the file extension) of the filename generated.
+If multiple source files would yield the same name, TMT aborts and reports the error.
+
+In generation sequence, each unquoted word equal to a single pipe character (`|`) is called a *pipe*.
+The word sequence is first split into generation commands by pipes.
+Each component represents a generation command, which represents a process when generating the test case:
+ - The first word of each command is the name of the generator.
+   - If the generator name is an unquoted special keyword `manual`, it copies the file found in `generator/manual` to the standard output.
+ - The remaining words of each command are the parameters to the generator.
+If any generation command is empty, the line is ill-formed.
+
+Generator processes are chained by pipes and the last generator output is used as the test case input.
+In particular:
+ - The first process receives nothing from the standard input.
+ - Each process, except for the last one, receives standard input from the standard output of the previous process via a pipe.
+ - The last process output is the test case input.
+ - The standard error of each process is kept as log files.
+
+If any of the process exists with a non-zero code, the generation sequence fails.
+
+Each generation sequence must be belong to a testset or subtask scope, see [`@testset` and `@subtask`](#testset-and-subtask).
+
+## Keywords
+
+To specify the structure of the test data, TMT recipes provide a set of keywords.
+
+The first word specifies the keyword command, and it must follow the respective format and constraints, or the line is considered ill-formed.
+
+
+Here is the list of all keywords:
+
+<!-- no toc -->
+- [`@testset` and `@subtask`](#testset-and-subtask)
+- [`@include`](#include)
+- [`@constant`](#constant)
+- [`@description`](#description)
+- [`@validation` and `@global_validation`](#validation-and-global_validation)
+- [`@extra_file`](#extra_file)
+
+### `@testset` and `@subtask`
+
+`@testset` and `@subtask` are used to declare testsets and subtasks.
+
+```
+@testset <name>
+@subtask <name> <score>
+```
+- `name`: the name of the testset/subtask.  
+  The name can only contain plain and special characters (i.e. base characters other than whitespaces).
+  Each testset and subtask must have a unique name.
+- `score`: the score of the subtask.  
+  It must be a real number between $-10^{100}$ and $10^{100}$.
+  The score is in C-style floating point decimal constant format.
+  It accepts decimal numbers and scientific notations, which is described by the following BNF:
+  ```
+  <float>       :=  <signed-frac> | <signed-frac> <exp>
+  <signed-frac> :=  <sign-opt> <frac>
+  <frac>        :=  <digit-seq> '.' <digit-seq> |
+                    <digit-seq> '.' |
+                    '.' <digit-seq>
+  <exp>         :=  'e' <sign-opt> <digit-seq> |
+                    'E' <sign-opt> <digit-seq>
+  <sign-opt>    :=  '+' | '-' | ''
+  <digit-seq>   :=  <digit> | <digit-seq> <digit>
+  <digit>       := '0' | '1' | ... | '9'
+  ```
+  If you need to use [Guaissan integers ($\mathbb Z[i]$)](https://en.wikipedia.org/wiki/Gaussian_integer) as score parameters, see this [guide](https://github.com/Task-Management-Tools/tmt-cli/compare).
+  <!-- TODO: when we have CONTRIBUTING.md, change this link -->
+
+As the name suggests, `@testset` starts a new testset, while `@subtask` starts a new subtask.
+We call this a *testset/subtask scope*.
+Before the first one is declared, the scope is called the *global scope*.
+
+Intuitively, the created testset or subtask contains every generation sequence after this command, until another one (any of testset or subtask) starts.
+
+In TMT, the score computation uses Python `float`.
+In practice, scores are usually integers between 0 and 100.
+If you need unusual score values (very large or small scores), please be aware of floating point precision loss and range limitations.
+
+<!-- For convenience, we collectively call subtask and testset as *test groups* and testset/subtask scopes as *group scopes*. -->
+
+### `@include`
+
+`@include` specifies the dependency of the current testset or subtask.
+
+```
+@include <name>
+```
+- `name`: the name of the testset/subtask.  
+  It must only contain plain and special characters (i.e. base characters other than whitespaces) and is an existing subtask or testset name before this command.
+
+`@include` command can only exist in testset/subtask scopes.
+It makes every test case in the included testset/subtask effectively also belong to the current one, without copying them.
+The inclusion relation is transitive.
+That is, if C includes B and B includes A, C will also contains all test cases from A.
+
+In problems with subtasks, it is very common for a subtask to include previous subtasks with tighter constraints.
+`@include` is exactly designed to represent this dependency.
+For example,
+```
+@subtask small 10
+gen -N 10 A
+gen -N 10 B
+gen -N 10 C
+
+@subtask medium 20
+@include small
+gen -N 400
+gen -N 500 A
+gen -N 500 B
+```
+Now subtask medium includes all test cases in subtask small.
+Any solution now needs to pass all 6 test cases in order to get accepted on subtask medium.
+This operation does not duplicate the testcases; the test cases in subtask small is judged exactly once, but the result is automatically propagated to subtask medium.
+
+If an `@include` command includes itself, it is effectively a no-op.
+
+### `@constant`
+
+`@constant` declates a constant that will be expanded in some other commands.
+```
+@constant <name> <value>
+```
+ - `name`: the name of the constant.  
+   It must be a constant name not used in the global scope and the current scope, containing only plain characters.
+ - `value`: the value of the constant.
+
+
+Constants lives within their respective scopes: in the global scope, it will be always available after its definition.
+In a testset/subtask scope, constants will vanish when the scope ends.
+
+To use a constant for variable expansion, put the name between `${` and `}`.
+For example,
+```
+@constant MAX-N 200
+
+@testset small
+@constant SMALL-N 10
+gen ${SMALL-N} A
+gen ${SMALL-N} B
+
+@testset large
+gen ${MAX-N}
+```
+expands to
+```
+@testset small
+gen 10 A
+gen 10 B
+
+@testset large
+gen 200
+```
+
+Constant expansion takes places after splitting a line to sequence of words and recognizing the comments.
+All of the recipe supports constant expansion except for the three cases below.
+
+ - Single-quoted words does not participate in constant expansion.
+ - Comments does not participate in constant expansion.
+ - Keyword lines [`@testset`](#testset-and-subtask), [`@subtask`](#testset-and-subtask), [`@include`](#include), [`@constant`](#constant), and [`@extra_file`](#extra_file) does not participate in constant expansion.
+
+In these cases, the variable references `${...}` will all stay as-is.
+
+This means, in the following example,
+```
+@testset hidden
+@constant ARGS 'adaptive mixed'
+@constant COMMENT '#not a comment'
+gen ${ARGS} ${COMMENT} '${ARGS}'
+```
+gives four words on line 3: `gen`, `adaptive mixed`, `#not a comment`, and `${ARGS}`.
+The second word is not split, the third word does not trigger comment detection, and the last word is kept verbatim since it is enclosed in single quotes.
+
+When expanding constants, if any variable references `${...}` uses a name that does not exist, the line is ill-formed.
+Fif new variable references `${...}` is formed after some constants expansion, the line is also ill-formed.
+This means you cannot try to nest constant expansions or construct it from several constants.
+
+
+### `@description`
+
+`@description` adds textual description to a testset or subtask.
+```
+@description ...
+```
+
+Keyword lines does not follow the usual word sequence splitting rule.
+After `@description` is identified, the parser removes leading and ending white spaces of the remaining part.
+The result participates in constant expansion and is set as the description of the testset or subtask verbatim.
+
+For example,
+```
+@constant MAX-N 1000
+@testset small
+@description    that's a small testset!
+
+@testset large
+@description    N <= ${MAX-N}?! only #1 can solve this set
+```
+will give descriptions `that's a small testset!` and `N <= 1000?! only #1 can solve this set` to testset small and large, respectively.
+
+`@description` it cannot be used in the global scope.
+Each testset and subtask can contain at most one `@description`, the second `@description` and onwards is ill-formed.
+
+### `@validation` and `@global_validation`
+
+`@validation` and `@global_validation` add validations to the testcases.
+```
+@validation <validation command>
+@global_validation <validation command>
+```
+- `validation command`: a validation command.
+
+Validators are prepared similarly to generators, except that it is found and compiled in directory `validator` and called validators.
+
+Validation commands are almost identical to generator commands.
+Each of the validation commands represents a validation to be run determine as follows.
+
+ - The first word of a validation command is the name of the validator.
+   - There is no special keyword called `manual`.
+ - The remaining words of a validation command are the parameters to the generator.
+ - Any single unquoted pipe in validation sequence is invalid.
+ - Empty validation sequence is invalid.
+
+The validator receives the test case input as the standard input.
+It must exit with the specific code to signify the test case input is valid.
+ - In ICPC judge convention, the code is 42 (see [ICPC package format](https://icpc.io/problem-package-format/spec/2025-09.html#exit-codes)).
+ - In other judge conventions, the code is 0.
+
+`@global_validation` adds the validation for all test cases, including those added in the future.
+`@validation` adds validation to the current testset/subtask.
+
+Testset and subtask validations will be run for every test case in this subtask, including those in depedencies.
+The ordering bewteen `@validation`, [`@include`](#include), and other test cases does not matter; validation applies to all test cases and dependencies in the scope.
+
+
+### `@extra_file`
+
+`@extra_file` adds extra files associated to the test cases.
+```
+@extra_file <name> [ext]
+```
+- `name`: the name of the constant.  
+  It must be a constant name not used in the global scope and the current scope, containing only plain characters.
+- `ext`: the file extension of the extra file.  
+  `ext` must start with a dot, and other characters must be plain characters.
+  If an `@extra_file` with the same name is defined in other scopes before, then `ext` can be omitted and the value will be whatever it is in the previous definition.
+  However, the same name should not map to another file extension, even across unrelated scopes.
+
+The name will be declared to be a special constant that expands to the filename used to store the extra file when generating the test case.
+
+If it is defined in global scope, every test case will have this extra file; if it is defined in testset/subtask scope, it only applies to the immediate test cases inside it and **will not propagate through dependencies**.
+
+When the special constant defined by `@extra_file` is used in validation commands, all dependency testsets/subtasks must also have this special constant defined.
+Otherwise, **the validation keyword line** is ill-formed.

--- a/internal/context/context.py
+++ b/internal/context/context.py
@@ -3,7 +3,7 @@ import pathlib
 import yaml
 
 
-from internal.recipe_parser import parse_recipe_data
+from internal.recipe_parser import RecipeData, parse_recipe_data
 from internal.exceptions import TMTMissingFileError, TMTInvalidConfigError
 
 from .paths import ProblemDirectoryHelper
@@ -44,10 +44,15 @@ class TMTContext:
         try:
             with open(self.path.tmt_recipe) as file:
                 # TODO: the last one feels hacky, but unless this is deferred there is no way to do this
-                self.recipe = parse_recipe_data(
+                recipe = parse_recipe_data(
                     file.readlines(),
                     self.config.problem_type == ProblemType.OUTPUT_ONLY,
                 )
+            if not isinstance(recipe, RecipeData):
+                raise ValueError(
+                    "\n".join([e.to_string(self.path.tmt_recipe) for e in recipe])
+                )
+            self.recipe = recipe
         except OSError as e:
             raise TMTMissingFileError("config", self.path.tmt_recipe) from e
         except ValueError as e:

--- a/internal/recipe_parser.py
+++ b/internal/recipe_parser.py
@@ -132,6 +132,8 @@ class Testset:
         """
         Include a testset in this testset.
         """
+        if testset is self:
+            return
         for deps in testset.dependency + [testset]:
             if deps not in self.dependency:
                 self.dependency.append(deps)
@@ -256,14 +258,13 @@ class RecipeData:
             return
 
         # From Python 3.7+ dict is order-preserving, so no sorting
-
         i = 1
         for testset in self.testsets.values():
             i = testset.assign_index(i)
 
-        # TODO: handle case when all testsets have no testcases (crashes with max() on empty)
         max_testset_index = max(
-            filter(None, (testset.index for testset in self.testsets.values()))
+            filter(None, (testset.index for testset in self.testsets.values())),
+            default=0,  # This won't matter anyway, just to prevent ValueError
         )
         testset_index_width = len(str(max_testset_index))
 
@@ -296,9 +297,8 @@ class RecipeData:
         """
         Let all test cases own their validations Executable
         This should be called after parsing is complete.
-        # TODO: validation propagation order is reversed; verify if this matches intended semantics
         """
-        for testset in reversed(self.testsets.values()):
+        for testset in self.testsets.values():
             for validation in self.global_validation:
                 testset.add_validation(validation)
             for depend in testset.dependency:
@@ -506,7 +506,6 @@ class RecipeParser:
         testsets = self.ctx.recipe_data.testsets
         if depend in testsets.keys():
             self.ctx.scope.include_testset(testsets[depend])
-        # TODO: detect and prevent circular @include dependencies (currently allows self-reference)
         else:
             raise ValueError(f"Unknown testset or subtask name: '{depend}'")
 

--- a/internal/recipe_parser.py
+++ b/internal/recipe_parser.py
@@ -6,20 +6,11 @@ This module parses a custom format file to generate recipe data structure object
 The parsed data includes testsets, subtasks, and validation rules for programming contests.
 """
 
-from dataclasses import dataclass
 import copy
+import functools
+import inspect
 import re
-from typing import List, Set, Optional
-
-
-@dataclass
-class ParseError:
-    message: str
-    line: int
-
-    def __str__(self):
-        # TODO!
-        raise NotImplementedError
+from typing import Literal, overload
 
 
 class Executable:
@@ -30,36 +21,36 @@ class Executable:
     follows the subprocess format (executable name + arguments).
     """
 
-    def __init__(self, command_sequence: str):
+    def __init__(self, commands: list[list[str]]):
         """
         Parse and add a command sequence separated by pipes.
 
         Args:
-            command_sequence (str): Commands separated by the pipe "|" character.
+            command_sequence (str or list of str): Commands separated by the pipe "|" character.
 
         Raises:
             ValueError: If command sequence is empty or malformed
         """
-
-        # TODO: support '' and ""
-        self.commands: List[List[str]] = []
-
-        if not command_sequence.strip():
-            raise ValueError("Command sequence is empty")
-
-        # Split by pipe and process each command
-        commands = command_sequence.split("|")
+        if len(commands) == 0:
+            raise ValueError("Executable command list should not be empty.")
         for cmd in commands:
-            cmd = cmd.strip()
-            if not cmd:
-                raise ValueError("Empty command found in sequence")
-
-            self.commands.append(cmd.split())
+            if len(cmd) == 0:
+                raise ValueError(
+                    "Executable command list should not contain empty subcommands."
+                )
+        self.commands = commands
 
     def __eq__(self, other):
         if not isinstance(other, Executable):
             return NotImplementedError
         return self.commands == other.commands
+
+
+class Validation(Executable):
+    def __init__(self, commands: list[list[str]]):
+        if len(commands) > 1:
+            raise ValueError("Validation command does not support piping.")
+        super().__init__(commands)
 
 
 TESTCASE_NAME_PLACE_HOLDER = "_tmt_internal_testcase_name"
@@ -72,11 +63,11 @@ class Testcase:
     Each test case contains an Executable object and its name
     """
 
-    def __init__(self, command_sequence: str):
-        self._raw_execute: Executable = Executable(command_sequence)
-        self.execute: Optional[Executable] = None
-        self.validation: List[Executable] = []
-        self._name: Optional[str] = None
+    def __init__(self, exe: Executable):
+        self._raw_execute: Executable = exe
+        self.execute: Executable | None = None
+        self.validation: list[Validation] = []
+        self._name: str | None = None
 
     @property
     def name(self):
@@ -99,12 +90,9 @@ class Testcase:
             for i, arg in enumerate(command_list):
                 command_list[i] = arg.replace(TESTCASE_NAME_PLACE_HOLDER, value)
 
-    def add_validation(self, validation: Executable):
+    def add_validation(self, validation: Validation):
         """
-        Add a validation Executable object for this test case.
-
-        Args:
-            validation (Executable): An Executable object representing a validation
+        Add a validation for this test case.
         """
         if validation not in self.validation:
             self.validation.append(validation)
@@ -119,12 +107,12 @@ class Testset:
 
     def __init__(self, name: str):
         self.name: str = name
-        self.index: Optional[int] = None
-        self.description: Optional[str] = None
-        self.validation: List[Executable] = []
-        self.testcases: List[Testcase] = []
-        self.dependency: List[Testset] = []
-        self.extra_file: Set[str] = set()
+        self.index: int | None = None
+        self.description: str | None = None
+        self.validation: list[Validation] = []
+        self.testcases: list[Testcase] = []
+        self.dependency: list[Testset] = []
+        self.extra_file: set[str] = set()
 
     def assign_index(self, index: int) -> int:
         """
@@ -133,36 +121,27 @@ class Testset:
         self.index = index
         return index + 1
 
-    def add_validation(self, executable: Executable):
+    def add_validation(self, validation: Validation):
         """
         Add a validation command for this testset.
-
-        Args:
-            executable (Executable): Validation executable
         """
-        if executable not in self.validation:
-            self.validation.append(executable)
+        if validation not in self.validation:
+            self.validation.append(validation)
 
     def include_testset(self, testset: "Testset"):
         """
         Include a testset in this testset.
-
-        Args:
-            testset (Testset): The testset to be included
         """
         for deps in testset.dependency + [testset]:
             if deps not in self.dependency:
                 self.dependency.append(deps)
 
-    def add_test(self, command_sequence: str):
+    def add_test(self, exe: Executable):
         """
-        Add a test case by parsing the command sequence.
-
-        Args:
-            command_sequence (str): Command sequence to generate test data
+        Add a test case by parsed the command sequence.
         """
         try:
-            self.testcases.append(Testcase(command_sequence))
+            self.testcases.append(Testcase(exe))
         except ValueError as e:
             raise ValueError(f"Error adding test to testset '{self.name}': {e}")
 
@@ -190,8 +169,6 @@ class Testset:
         Raises:
             ValueError: If the extension format error or it is already added
         """
-        if len(extension) == 0 or extension[0] != ".":
-            raise ValueError(f"Extra file {extension} should start with a dot (.)")
         if extension in self.extra_file:
             raise ValueError(
                 f"Extra file {extension} already added for testset '{self.name}'"
@@ -251,14 +228,14 @@ class RecipeData:
     def __init__(self):
         self.testsets: dict[str, Testset | Subtask] = {}
         self.subtasks: dict[str, Subtask] = {}
-        self.global_validation: List[Executable] = []
+        self.global_validation: list[Validation] = []
 
-    def get_all_test_names(self) -> List[str]:
+    def get_all_test_names(self) -> list[str]:
         """
         Get all test names in order.
 
         Returns:
-            List[str]: List of all test names sorted by testset index and testcase index
+            list[str]: List of all test names sorted by testset index and testcase index
         """
         all_names = []
 
@@ -284,6 +261,7 @@ class RecipeData:
         for testset in self.testsets.values():
             i = testset.assign_index(i)
 
+        # TODO: handle case when all testsets have no testcases (crashes with max() on empty)
         max_testset_index = max(
             filter(None, (testset.index for testset in self.testsets.values()))
         )
@@ -318,6 +296,7 @@ class RecipeData:
         """
         Let all test cases own their validations Executable
         This should be called after parsing is complete.
+        # TODO: validation propagation order is reversed; verify if this matches intended semantics
         """
         for testset in reversed(self.testsets.values()):
             for validation in self.global_validation:
@@ -343,25 +322,24 @@ class ParserContext:
 
     def __init__(self):
         self.recipe_data = RecipeData()
-        self.current_context = None
-        self.current_object = None
-        self.used_names = set()
+        self._scope: Testset | Subtask | None = None
 
-        # Shared data storage for inter-handler communication
-        self.constants = {}  # For storing user-defined constants
+        # For storing user-defined constants
+        self.global_const: dict[str, str] = {}
+        self.local_const: dict[str, str] = {}
 
-    def get_constant(self, name: str, default=None):
-        """
-        Get a constant value by name.
+    @property
+    def scope(self):
+        return self._scope
 
-        Args:
-            name (str): Constant name
-            default: Default value if constant doesn't exist
+    @scope.setter
+    def scope(self, value: Testset | Subtask | None):
+        self._scope = value
+        self.local_const.clear()
 
-        Returns:
-            Constant value or default
-        """
-        return self.constants.get(name, default)
+    @property
+    def const_mapping(self):
+        return self.global_const | self.local_const
 
     def set_constant(self, name: str, value):
         """
@@ -371,260 +349,202 @@ class ParserContext:
             name (str): Constant name
             value: Constant value
         """
-        if self.has_constant(name) and self.constants[name] != value:
+        target_const = self.local_const if self.scope is not None else self.global_const
+        if name in target_const:
             raise ValueError(f"Redefinition on constant {name}")
-        self.constants[name] = value
+        target_const[name] = value
 
-    def has_constant(self, name: str) -> bool:
-        """
-        Check if a constant exists.
+    @overload
+    def shell_split(self, cmdline: str, pipe_split: Literal[False]) -> list[str]: ...
+    @overload
+    def shell_split(
+        self, cmdline: str, pipe_split: Literal[True]
+    ) -> list[list[str]]: ...
 
-        Args:
-            name (str): Constant name
-
-        Returns:
-            bool: True if constant exists
-        """
-        return name in self.constants
-
-    def expand_constants(self, text: str) -> str:
-        """
-        Expand constants in text using ${constant_name} syntax.
-
-        Args:
-            text (str): Text potentially containing constant references
-
-        Returns:
-            str: Text with constants expanded
-
-        Raises:
-            ValueError: If referenced constant doesn't exist
-        """
-
-        def replace_var(match):
+    def substitute(self, text: str) -> str:
+        def replace_var(match: re.Match):
             var_name = match.group(1)
-            if not self.has_constant(var_name):
-                raise ValueError(f"Undefined constant: ${{{var_name}}}")
-            return str(self.constants[var_name])
+            var_val = self.const_mapping.get(var_name)
+            if var_val is None:
+                raise ValueError(f"Undefined constant: {match.group(0)}")
+            return var_val
 
         # Replace ${constant_name} patterns
         return re.sub(r"\$\{([^}]+)\}", replace_var, text)
 
-    def list_expand_constants(self, list_of_text: List[str]):
-        """
-        Expand constants in list of text using ${constant_name} syntax.
+    def shell_split(self, cmdline: str, pipe_split: bool):
 
-        Args:
-            list_of_text (list of str): List of text potentially containing constant references
+        # Strip beginning whitespaces, and add a single after it so tokenizing works:
+        cmdline = cmdline.strip() + " "
+        cmds = []
+        cmd = []
+        # Python alternative (|) is eager, so the quoted alternatives always matches first if possible.
+        for m in re.finditer(r"(?:\"([^\"]*)\"|\'([^\']*)\'|(\|)|(\S+))\s+", cmdline):
+            if m.group(1) is not None:  # double-quoted
+                cmd.append(self.substitute(m.group(1)))
+            elif m.group(2) is not None:  # single-quoted
+                cmd.append(m.group(2))
+            elif m.group(3):  # unquoted pipe
+                if pipe_split:
+                    cmds.append(cmd)
+                    cmd = []
+                else:
+                    cmd.append("|")
+            else:  # bare word
+                cmd.append(self.substitute(m.group(4)))
+        cmds.append(cmd)
+        return cmds if pipe_split else cmd
 
-        Raises:
-            ValueError: If referenced constant doesn't exist
-        """
-        for i, s in enumerate(list_of_text):
-            list_of_text[i] = self.expand_constants(s)
-
-
-class CommandHandler:
-    """
-    Base class for handling different types of commands.
-    """
-
-    def __init__(self, parser_context: ParserContext):
-        self.context = parser_context
-
-    def validate_args(
-        self, parts: List[str], min_args: int, max_args: int | None = None
-    ):
-        """
-        Validate the number of arguments for a command.
-
-        Args:
-            parts (List[str]): Command parts including the command name
-            min_args (int): Minimum number of arguments (excluding command name)
-            max_args (int, optional): Maximum number of arguments
-        """
-        arg_count = len(parts) - 1
-        if arg_count < min_args:
-            raise ValueError(f"@{parts[0]} requires at least {min_args} argument(s)")
-        if max_args is not None and arg_count > max_args:
-            raise ValueError(f"@{parts[0]} requires at most {max_args} argument(s)")
+    def make_executable(self, cmdline: str, type: type[Executable] | type[Validation]):
+        return type(self.shell_split(cmdline, pipe_split=True))
 
 
-class TestsetHandler(CommandHandler):
-    """Handler for @testset commands."""
+class RecipeParser:
+    def __init__(self):
+        self.ctx = ParserContext()
 
-    def handle(self, parts: List[str]):
-        self.validate_args(parts, 1, 1)
+        # Register all handlers marked by the decorator
+        self.handlers = {
+            obj._cmd_name: getattr(self, obj.__name__)
+            for obj in self.__class__.__dict__.values()
+            if callable(obj) and hasattr(obj, "_cmd_name")
+        }
 
-        testset_name = parts[1]
-        if testset_name in self.context.recipe_data.testsets.keys():
-            raise ValueError(f"Name '{testset_name}' already used")
+    def _register_command(name: str, preprocess=True):
+        def decorator(func):
+            # Count only parameters that are positional or positional-or-keyword
+            params = inspect.signature(func).parameters.values()
+            num_args = sum(
+                1
+                for p in params
+                if p.kind
+                in (
+                    inspect.Parameter.POSITIONAL_ONLY,
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                )
+            )
+            variadic = any(
+                True for p in params if p.kind == inspect.Parameter.VAR_POSITIONAL
+            )
 
-        testset = Testset(testset_name)
-        self.context.recipe_data.testsets[testset_name] = testset
-        self.context.current_context = "testset"
-        self.context.current_object = testset
+            if any(True for p in params if p.kind == inspect.Parameter.KEYWORD_ONLY):
+                raise TypeError(
+                    "Command handler registered must not have keyword-only parameter"
+                )
+            if any(True for p in params if p.kind == inspect.Parameter.VAR_KEYWORD):
+                raise TypeError(
+                    "Command handler registered must not have keyword-only variadic parameter"
+                )
+            if not preprocess and num_args != 2:
+                raise TypeError(
+                    "Command handler registered without preprocessing must have exactly one positional parameter"
+                )
 
+            @functools.wraps(func)
+            def wrapper(*args):
+                # Also counts self as one of them, so diagnostics returns -1
+                if len(args) < num_args:
+                    raise ValueError(
+                        f"@{name} requires at least {num_args - 1} argument(s)"
+                    )
+                if not variadic and len(args) != num_args:
+                    raise ValueError(
+                        f"@{name} requires exactly {num_args - 1} argument(s)"
+                    )
+                result = func(*args)
+                return result
 
-class SubtaskHandler(CommandHandler):
-    """Handler for @subtask commands."""
+            wrapper._cmd_name = name
+            wrapper.preprocess = preprocess
+            return wrapper
 
-    def handle(self, parts: List[str]):
-        self.validate_args(parts, 2, 2)
+        return decorator
 
-        subtask_name = parts[1]
-        if subtask_name in self.context.recipe_data.testsets.keys():
-            raise ValueError(f"Name '{subtask_name}' already used")
+    @_register_command("testset")
+    def command_testset(self, name: str):
 
+        if name in self.ctx.recipe_data.testsets.keys():
+            raise ValueError(f"Name '{name}' already used")
+
+        testset = Testset(name)
+        self.ctx.recipe_data.testsets[name] = testset
+        self.ctx.scope = testset
+
+    @_register_command("subtask")
+    def command_subtask(self, name: str, score_s: str):
         try:
-            score = int(parts[2])
+            score = int(score_s)
         except ValueError:
-            raise ValueError(f"Invalid score '{parts[2]}' for subtask")
+            raise ValueError(f"Invalid score '{score_s}' for subtask")
 
-        subtask = Subtask(subtask_name, score)
-        self.context.recipe_data.testsets[subtask_name] = subtask
-        self.context.recipe_data.subtasks[subtask_name] = subtask
-        self.context.current_context = "subtask"
-        self.context.current_object = subtask
+        if name in self.ctx.recipe_data.testsets.keys():
+            raise ValueError(f"Name '{name}' already used")
 
+        subtask = Subtask(name, score)
+        self.ctx.recipe_data.testsets[name] = subtask
+        self.ctx.recipe_data.subtasks[name] = subtask
+        self.ctx.scope = subtask
 
-class GlobalValidationHandler(CommandHandler):
-    """Handler for @global_validation commands."""
-
-    def handle(self, parts: List[str]):
-        self.validate_args(parts, 1)
-
-        self.context.list_expand_constants(parts)
-        command_sequence = " ".join(parts[1:])
-        executable = Executable(command_sequence)
-        self.context.recipe_data.global_validation.append(executable)
-        self.context.current_context = None
-        self.context.current_object = None
-
-
-class DescriptionHandler(CommandHandler):
-    """Handler for @description commands."""
-
-    def handle(self, parts: List[str]):
-        self.validate_args(parts, 1)
-
-        if self.context.current_context is None:
+    @_register_command("description", preprocess=False)
+    def command_description(self, desc: str):
+        if self.ctx.scope is None:
             raise ValueError(
                 "@description can only be used within testset or subtask context"
             )
 
-        self.context.list_expand_constants(parts)
-        description = " ".join(parts[1:])
-        self.context.current_object.set_description(description)
+        desc = self.ctx.substitute(desc)
+        self.ctx.scope.set_description(desc)
 
+    @_register_command("include")
+    def command_include(self, depend: str):
 
-class IncludeHandler(CommandHandler):
-    """Handler for @include commands."""
-
-    def handle(self, parts: List[str]):
-        self.validate_args(parts, 1, 1)
-
-        if self.context.current_context is None:
+        if self.ctx.scope is None:
             raise ValueError(
                 "@include can only be used within testset or subtask context"
             )
 
-        include_name = parts[1]
-
-        # Check if it's a testset or subtask
-        testsets = self.context.recipe_data.testsets
-        if include_name in testsets.keys():
-            self.context.current_object.include_testset(testsets[include_name])
+        testsets = self.ctx.recipe_data.testsets
+        if depend in testsets.keys():
+            self.ctx.scope.include_testset(testsets[depend])
+        # TODO: detect and prevent circular @include dependencies (currently allows self-reference)
         else:
-            raise ValueError(f"Unknown testset or subtask name: '{include_name}'")
+            raise ValueError(f"Unknown testset or subtask name: '{depend}'")
 
+    @_register_command("global_validation", preprocess=False)
+    def command_global_validation(self, remain: str):
+        val = self.ctx.make_executable(remain, Validation)
+        self.ctx.recipe_data.global_validation.append(val)
 
-class ValidationHandler(CommandHandler):
-    """Handler for @validation commands."""
+    @_register_command("validation", preprocess=False)
+    def command_validation(self, remain: str):
 
-    def handle(self, parts: List[str]):
-        self.validate_args(parts, 1)
-
-        if self.context.current_context not in ("testset", "subtask"):
+        if self.ctx.scope is None:
             raise ValueError(
                 "@validation can only be used within testset or subtask context"
             )
 
-        self.context.list_expand_constants(parts)
-        self.context.current_object.add_validation(Executable(" ".join(parts[1:])))
+        val = self.ctx.make_executable(remain, Validation)
+        self.ctx.scope.add_validation(val)
 
+    @_register_command("constant")
+    def command_constant(self, name: str, value: str):
+        self.ctx.set_constant(name, value)
 
-class ConstantHandler(CommandHandler):
-    """Handler for @constant commands."""
-
-    def handle(self, parts: List[str]):
-        self.validate_args(parts, 2, 2)
-
-        self.context.set_constant(parts[1], parts[2])
-
-
-class ExtrafileHandler(CommandHandler):
-    """Handler for @extra_file commands."""
-
-    def handle(self, parts: List[str]):
-        self.validate_args(parts, 2, 2)
-
-        if self.context.current_context not in ("testset", "subtask"):
+    @_register_command("extra_file")
+    def command_extra_file(self, name: str, ext: str):
+        if self.ctx.scope is None:
             raise ValueError(
                 "@extra_file can only be used within testset or subtask context"
             )
+        if not ext.startswith("."):
+            raise ValueError(f"Extra file {ext} should start with a dot (.)")
 
-        self.context.current_object.add_extrafile(parts[2])
-        self.context.set_constant(parts[1], TESTCASE_NAME_PLACE_HOLDER + parts[2])
-
-
-class CommandRegistry:
-    """
-    Registry for all available command handlers.
-    """
-
-    def __init__(self, parser_context: ParserContext):
-        self.handlers = {
-            "testset": TestsetHandler(parser_context),
-            "subtask": SubtaskHandler(parser_context),
-            "global_validation": GlobalValidationHandler(parser_context),
-            "description": DescriptionHandler(parser_context),
-            "include": IncludeHandler(parser_context),
-            "validation": ValidationHandler(parser_context),
-            "constant": ConstantHandler(parser_context),
-            "extra_file": ExtrafileHandler(parser_context),
-        }
-
-    def get_handler(self, command: str) -> CommandHandler:
-        """
-        Get the handler for a specific command.
-
-        Args:
-            command (str): Command name
-
-        Returns:
-            CommandHandler: Handler for the command
-
-        Raises:
-            ValueError: If command is not recognized
-        """
-        if command not in self.handlers:
-            raise ValueError(f"Unknown command: '@{command}'")
-        return self.handlers[command]
-
-    def register_handler(self, command: str, handler: CommandHandler):
-        """
-        Register a new command handler.
-
-        Args:
-            command (str): Command name
-            handler (CommandHandler): Handler instance
-        """
-        self.handlers[command] = handler
+        self.ctx.scope.add_extrafile(ext)
+        self.ctx.set_constant(name, TESTCASE_NAME_PLACE_HOLDER + ext)
 
 
 def parse_recipe_data(
-    recipe_lines: List[str], is_outputonly: bool = False
+    recipe_lines: list[str], is_outputonly: bool = False
 ) -> RecipeData:
     """
     Parse recipe and return the structured data.
@@ -642,45 +562,52 @@ def parse_recipe_data(
         ValueError: If the recipe format is invalid
     """
 
-    parser_context = ParserContext()
-    command_registry = CommandRegistry(parser_context)
+    parser = RecipeParser()
 
     for line_num, line in enumerate(recipe_lines, 1):
         line = line.strip()
 
-        # Skip empty lines and comments
-        if not line or line.startswith("#"):
+        # Remove comments
+        line = line.partition("#")[0].strip()
+        if not line:
             continue
 
         try:
             # Handle command lines starting with @
             if line.startswith("@"):
-                parts = line[1:].split()
-                if not parts:
-                    raise ValueError("Empty command after '@'")
+                cmd, *args = line.split(maxsplit=1)
+                args = args[0] if args else ""
 
-                command = parts[0]
-                handler = command_registry.get_handler(command)
-                handler.handle(parts)
+                handler = parser.handlers.get(cmd[1:])
+                if handler is None:
+                    raise ValueError(f"Unknown command {cmd}")
+                if handler.preprocess:
+                    handler(*parser.ctx.shell_split(args, pipe_split=False))
+                else:
+                    handler(args)
 
             else:
                 # Expand constants in test generation commands
-                expanded_line = parser_context.expand_constants(line)
-                parser_context.current_object.add_test(expanded_line)
+                exe = parser.ctx.make_executable(line, Executable)
+                if parser.ctx.scope is None:
+                    raise ValueError(
+                        "Stray generation command not within any subtask or testset"
+                    )
+                parser.ctx.scope.add_test(exe)
 
         except ValueError as e:
             raise ValueError(f"Error on line {line_num}: {e}")
 
     # Generate test names after parsing is complete
     if is_outputonly:
-        parser_context.recipe_data.generate_testsetless_test_names()
+        parser.ctx.recipe_data.generate_testsetless_test_names()
     else:
-        parser_context.recipe_data.generate_all_test_names()
+        parser.ctx.recipe_data.generate_all_test_names()
 
     # Push validations to all test cases after parsing is complete
-    parser_context.recipe_data.push_validation_to_testcases()
+    parser.ctx.recipe_data.push_validation_to_testcases()
 
-    return parser_context.recipe_data
+    return parser.ctx.recipe_data
 
 
 if __name__ == "__main__":
@@ -765,12 +692,10 @@ print 1 1
 
         print("\n=== SUBTASKS ===")
         for name, subtask in recipe_data.subtasks.items():
-            print(
-                f"Subtask '{name}' (index: {subtask.subtask_index}, score: {subtask.score})"
-            )
+            print(f"Subtask '{name}' (index: {subtask.index}, score: {subtask.score})")
             if subtask.description:
                 print(f"  Description: {subtask.description}")
-            print(f"  Testsets: {sorted(subtask.tests)}")
+            print(f"  Testsets: {subtask.dependency}")
             print(f"  Validation: {len(subtask.validation)} validators")
             for i, validation in enumerate(subtask.validation):
                 print(f"    Validator {i + 1}: {validation.commands}")
@@ -781,3 +706,4 @@ print 1 1
         pass
     # except Exception as e:
     #     print(f"Error: {e}")
+    # print(shell_split("a | b '|' c", {}))

--- a/internal/recipe_parser.py
+++ b/internal/recipe_parser.py
@@ -15,7 +15,7 @@ import re
 from typing import Literal, overload
 
 
-class Executable:
+class Command:
     """
     Represents an executable command with multiple programs to run sequentially and connected by pipes.
 
@@ -35,21 +35,19 @@ class Executable:
             ValueError: If commands is empty or contains empty subcommands
         """
         if len(commands) == 0:
-            raise ValueError("Executable command list should not be empty")
+            raise ValueError("Command list should not be empty")
         for cmd in commands:
             if len(cmd) == 0:
-                raise ValueError(
-                    "Executable command list should not contain empty subcommands"
-                )
+                raise ValueError("Command list should not contain empty subcommands")
         self.commands = commands
 
     def __eq__(self, other):
-        if not isinstance(other, Executable):
+        if not isinstance(other, Command):
             return NotImplementedError
         return self.commands == other.commands
 
 
-class Validation(Executable):
+class Validation(Command):
     """Validation command; similar to Executable but only allows one subcommand."""
 
     def __init__(self, commands: list[list[str]]):
@@ -62,10 +60,10 @@ TESTCASE_NAME_PLACE_HOLDER = "_tmt_internal_testcase_name"
 
 
 class Testcase:
-    def __init__(self, exe: Executable):
+    def __init__(self, exe: Command):
         """Initialize testcase with an executable."""
-        self._raw_execute: Executable = exe
-        self.execute: Executable | None = None
+        self._raw_execute: Command = exe
+        self.execute: Command | None = None
         self.validation: list[Validation] = []
         self._name: str | None = None
 
@@ -132,7 +130,7 @@ class Testset:
             if deps not in self.dependency:
                 self.dependency.append(deps)
 
-    def add_test(self, exe: Executable):
+    def add_test(self, exe: Command):
         """
         Add a test case from the generation Executable.
         """
@@ -393,7 +391,7 @@ class ParserContext:
         cmds.append(cmd)
         return cmds if pipe_split else cmd
 
-    def make_executable(self, cmdline: str, type: type[Executable] | type[Validation]):
+    def make_executable(self, cmdline: str, type: type[Command] | type[Validation]):
         return type(self.shell_split(cmdline, pipe_split=True))
 
 
@@ -584,7 +582,7 @@ class RecipeParser:
 
                 else:
                     # Expand constants in test generation commands
-                    exe = self.ctx.make_executable(line, Executable)
+                    exe = self.ctx.make_executable(line, Command)
                     if self.ctx.scope is None:
                         raise ValueError(
                             "Stray generation command (not within any subtask or testset)"
@@ -630,102 +628,3 @@ def parse_recipe_data(
     parser.ctx.recipe_data.push_validation_to_testcases()
 
     return parser.ctx.recipe_data
-
-
-if __name__ == "__main__":
-    # Test the parser with sample data
-    sample_data = """
-@global_validation validator
-
-@testset samples
-manual s1.in
-manual s2.in
-
-@testset handmade
-print 30 11 | swap
-print 30 22 | swap
-print 47 24
-print 2147483647 1
-print 2147483647 2147483647
-manual 1.in
-
-@subtask A 1
-print 1 1
-
-@subtask B 2
-@include A
-@include A
-
-@subtask C 3
-@include B
-@include B
-
-@subtask D 4
-@include C
-@include C
-
-@subtask E 5
-@include D
-@include D
-
-@subtask F 6
-@include E
-@include E
-
-@subtask G 7
-@include F
-@include F
-
-@subtask H 8
-@validation validator
-@include G
-@include G
-"""
-
-    try:
-        # Parse the sample data
-        recipe_data = parse_recipe_data(sample_data.split("\n"))
-
-        # Print parsed results
-        print("=== TESTSETS ===")
-        for name, testset in recipe_data.testsets.items():
-            print(f"Testset '{name}' (index: {testset.index})")
-            if len(testset.extra_file) != 0:
-                print(f"  Extra files: {list(testset.extra_file)}")
-            if testset.description:
-                print(f"  Description: {testset.description}")
-            print(f"  Tests: {len(testset.testcases)}")
-            for i, test in enumerate(testset.testcases):
-                print(
-                    f"    Test {i + 1} (Name: {test.name}): {len(test.execute.commands)} commands"
-                )
-                for j, cmd in enumerate(test.execute.commands):
-                    print(f"      Command {j + 1}: {cmd}")
-                print(
-                    f"      Validation for test {i + 1}: {len(test.validation)} validators"
-                )
-                for j, validation in enumerate(test.validation):
-                    print(f"        Validator {j + 1}: {validation.commands}")
-
-        print("\n=== GLOBAL VALIDATION ===")
-        print(f"Global validation: {len(recipe_data.global_validation)} validators")
-        for i, validation in enumerate(recipe_data.global_validation):
-            print(f"  Global validation {i + 1}: {validation.commands}")
-
-        print("\n=== SUBTASKS ===")
-        for name, subtask in recipe_data.subtasks.items():
-            print(f"Subtask '{name}' (index: {subtask.index}, score: {subtask.score})")
-            if subtask.description:
-                print(f"  Description: {subtask.description}")
-            print(f"  Testsets: {subtask.dependency}")
-            print(f"  Validation: {len(subtask.validation)} validators")
-            for i, validation in enumerate(subtask.validation):
-                print(f"    Validator {i + 1}: {validation.commands}")
-
-        print("\nParsing completed successfully!")
-
-    finally:
-        pass
-    # except Exception as e:
-    #     print(f"Error: {e}")
-    # print(shell_split("a | b '|' c", {}))

--- a/internal/recipe_parser.py
+++ b/internal/recipe_parser.py
@@ -536,7 +536,7 @@ class RecipeParser:
 
         if self.ctx.scope is None:
             raise ValueError(
-                "@validation can only be used within testset or subtask context"
+                "@validation can only be used within testset or subtask context; use @global_validation instead"
             )
 
         val = self.ctx.make_executable(remain, Validation)

--- a/internal/recipe_parser.py
+++ b/internal/recipe_parser.py
@@ -7,15 +7,17 @@ The parsed data includes testsets, subtasks, and validation rules for programmin
 """
 
 import copy
+from dataclasses import dataclass
 import functools
 import inspect
+import os
 import re
 from typing import Literal, overload
 
 
 class Executable:
     """
-    Represents an executable command with multiple programs to run sequentially.
+    Represents an executable command with multiple programs to run sequentially and connected by pipes.
 
     Each executable contains a list of command lists, where each command list
     follows the subprocess format (executable name + arguments).
@@ -23,20 +25,21 @@ class Executable:
 
     def __init__(self, commands: list[list[str]]):
         """
-        Parse and add a command sequence separated by pipes.
+        Initialize executable with a list of command lists (one per pipeline stage).
 
         Args:
-            command_sequence (str or list of str): Commands separated by the pipe "|" character.
+            commands: List of command lists, where each inner list contains
+                      [command_name, arg1, arg2, ...]. Empty lists are not allowed.
 
         Raises:
-            ValueError: If command sequence is empty or malformed
+            ValueError: If commands is empty or contains empty subcommands
         """
         if len(commands) == 0:
-            raise ValueError("Executable command list should not be empty.")
+            raise ValueError("Executable command list should not be empty")
         for cmd in commands:
             if len(cmd) == 0:
                 raise ValueError(
-                    "Executable command list should not contain empty subcommands."
+                    "Executable command list should not contain empty subcommands"
                 )
         self.commands = commands
 
@@ -47,9 +50,11 @@ class Executable:
 
 
 class Validation(Executable):
+    """Validation command; similar to Executable but only allows one subcommand."""
+
     def __init__(self, commands: list[list[str]]):
         if len(commands) > 1:
-            raise ValueError("Validation command does not support piping.")
+            raise ValueError("Validation command does not support piping")
         super().__init__(commands)
 
 
@@ -57,13 +62,8 @@ TESTCASE_NAME_PLACE_HOLDER = "_tmt_internal_testcase_name"
 
 
 class Testcase:
-    """
-    Represents a test case.
-
-    Each test case contains an Executable object and its name
-    """
-
     def __init__(self, exe: Executable):
+        """Initialize testcase with an executable."""
         self._raw_execute: Executable = exe
         self.execute: Executable | None = None
         self.validation: list[Validation] = []
@@ -122,16 +122,10 @@ class Testset:
         return index + 1
 
     def add_validation(self, validation: Validation):
-        """
-        Add a validation command for this testset.
-        """
         if validation not in self.validation:
             self.validation.append(validation)
 
     def include_testset(self, testset: "Testset"):
-        """
-        Include a testset in this testset.
-        """
         if testset is self:
             return
         for deps in testset.dependency + [testset]:
@@ -140,19 +134,14 @@ class Testset:
 
     def add_test(self, exe: Executable):
         """
-        Add a test case by parsed the command sequence.
+        Add a test case from the generation Executable.
         """
-        try:
-            self.testcases.append(Testcase(exe))
-        except ValueError as e:
-            raise ValueError(f"Error adding test to testset '{self.name}': {e}")
+        tc = Testcase(exe)
+        self.testcases.append(tc)
 
     def set_description(self, description: str):
         """
         Set the description for this testset.
-
-        Args:
-            description (str): Description text
 
         Raises:
             ValueError: If description is already set
@@ -169,30 +158,30 @@ class Testset:
             extension (str): Extra file extension, should start with a dot (.)
 
         Raises:
-            ValueError: If the extension format error or it is already added
+            ValueError: If the extension is already added
         """
         if extension in self.extra_file:
             raise ValueError(
-                f"Extra file {extension} already added for testset '{self.name}'"
+                f"Extra file '{extension}' already added for testset '{self.name}'"
             )
         self.extra_file.add(extension)
 
     def generate_test_names(self, testset_index_width: int):
         """
         Generate standardized names for all test cases in this testset.
-
-        Args:
-            testset_index_width (int): Width for zero-padding testset index
         """
         testcase_index_width = len(str(len(self.testcases)))
         testset_index_padded = str(self.index).zfill(testset_index_width)
 
         for i, test in enumerate(self.testcases, 1):
             testcase_index_padded = str(i).zfill(testcase_index_width)
-            test_name = f"{testset_index_padded}_{self.name}_{testcase_index_padded}"
-            test.name = test_name
+            test.name = f"{testset_index_padded}_{self.name}_{testcase_index_padded}"
 
-    def get_all_test_names(self):
+    def get_all_test_names(self) -> list[str]:
+        """
+        Get all test names in this testset, including dependencies.
+        """
+
         return sum(
             ([tc.name for tc in ts.testcases] for ts in (self.dependency + [self])),
             start=[],
@@ -234,19 +223,14 @@ class RecipeData:
 
     def get_all_test_names(self) -> list[str]:
         """
-        Get all test names in order.
-
-        Returns:
-            list[str]: List of all test names sorted by testset index and testcase index
+        Get all test names based on recipe order.
         """
-        all_names = []
-
         # From Python 3.7+ dict is order-preserving
+        all_names = []
         for testset in self.testsets.values():
             for test in testset.testcases:
                 if test.name:
                     all_names.append(test.name)
-
         return all_names
 
     def generate_all_test_names(self):
@@ -334,6 +318,7 @@ class ParserContext:
 
     @scope.setter
     def scope(self, value: Testset | Subtask | None):
+        """Set current scope and clear local constants."""
         self._scope = value
         self.local_const.clear()
 
@@ -341,40 +326,53 @@ class ParserContext:
     def const_mapping(self):
         return self.global_const | self.local_const
 
-    def set_constant(self, name: str, value):
-        """
-        Set a constant value.
+    def set_constant(self, name: str, value: str):
+        """Set a constant value."""
 
-        Args:
-            name (str): Constant name
-            value: Constant value
-        """
         target_const = self.local_const if self.scope is not None else self.global_const
         if name in target_const:
-            raise ValueError(f"Redefinition on constant {name}")
+            raise ValueError(f"Redefinition on constant '{name}'")
         target_const[name] = value
 
     @overload
     def shell_split(self, cmdline: str, pipe_split: Literal[False]) -> list[str]: ...
+
     @overload
     def shell_split(
         self, cmdline: str, pipe_split: Literal[True]
     ) -> list[list[str]]: ...
 
     def substitute(self, text: str) -> str:
+        """
+        Replace ${constant} patterns with their values.
+
+        Raises:
+            ValueError: If a referenced constant is undefined
+        """
+
         def replace_var(match: re.Match):
             var_name = match.group(1)
             var_val = self.const_mapping.get(var_name)
+            # TODO: this abruptly stops the substitution; if multiple fails this only reports the first one
             if var_val is None:
-                raise ValueError(f"Undefined constant: {match.group(0)}")
+                raise ValueError(f"Undefined constant '{var_name}'")
             return var_val
 
         # Replace ${constant_name} patterns
         return re.sub(r"\$\{([^}]+)\}", replace_var, text)
 
     def shell_split(self, cmdline: str, pipe_split: bool):
+        """
+        Tokenize a command line, supporting quotes and pipes.
 
-        # Strip beginning whitespaces, and add a single after it so tokenizing works:
+        Handles double quotes ("..."), single quotes ('...'), unquoted pipes (|),
+        and bare words. Constants are substituted in unquoted text only.
+
+        Args:
+            cmdline: Command line string to tokenize
+            pipe_split: If True, split on pipes and return list of command lists.
+                        If False, return flat list of tokens with '|' preserved.
+        """
         cmdline = cmdline.strip() + " "
         cmds = []
         cmd = []
@@ -399,6 +397,15 @@ class ParserContext:
         return type(self.shell_split(cmdline, pipe_split=True))
 
 
+@dataclass
+class RecipeParsingError:
+    line_no: int
+    reason: str
+
+    def to_string(self, recipe_path: str):
+        return f"{os.path.relpath(recipe_path, os.getcwd())}:{self.line_no}: error: {self.reason}"
+
+
 class RecipeParser:
     def __init__(self):
         self.ctx = ParserContext()
@@ -411,6 +418,17 @@ class RecipeParser:
         }
 
     def _register_command(name: str, preprocess=True):
+        """
+        Decorator to register command handlers with argument validation.
+
+        Validates handler signature: rejects keyword-only and **kwargs params.
+        Wraps handler to check argument count at runtime.
+
+        Args:
+            name: Command name (without @ prefix)
+            preprocess: If True, shell-split arguments. If False, pass raw string after the command.
+        """
+
         def decorator(func):
             # Count only parameters that are positional or positional-or-keyword
             params = inspect.signature(func).parameters.values()
@@ -427,13 +445,14 @@ class RecipeParser:
                 True for p in params if p.kind == inspect.Parameter.VAR_POSITIONAL
             )
 
-            if any(True for p in params if p.kind == inspect.Parameter.KEYWORD_ONLY):
+            if any(
+                True
+                for p in params
+                if p.kind
+                in (inspect.Parameter.KEYWORD_ONLY, inspect.Parameter.VAR_KEYWORD)
+            ):
                 raise TypeError(
                     "Command handler registered must not have keyword-only parameter"
-                )
-            if any(True for p in params if p.kind == inspect.Parameter.VAR_KEYWORD):
-                raise TypeError(
-                    "Command handler registered must not have keyword-only variadic parameter"
                 )
             if not preprocess and num_args != 2:
                 raise TypeError(
@@ -464,7 +483,7 @@ class RecipeParser:
     def command_testset(self, name: str):
 
         if name in self.ctx.recipe_data.testsets.keys():
-            raise ValueError(f"Name '{name}' already used")
+            raise ValueError(f"Testset name '{name}' already used")
 
         testset = Testset(name)
         self.ctx.recipe_data.testsets[name] = testset
@@ -478,7 +497,7 @@ class RecipeParser:
             raise ValueError(f"Invalid score '{score_s}' for subtask")
 
         if name in self.ctx.recipe_data.testsets.keys():
-            raise ValueError(f"Name '{name}' already used")
+            raise ValueError(f"Subtask name '{name}' already used")
 
         subtask = Subtask(name, score)
         self.ctx.recipe_data.testsets[name] = subtask
@@ -541,10 +560,45 @@ class RecipeParser:
         self.ctx.scope.add_extrafile(ext)
         self.ctx.set_constant(name, TESTCASE_NAME_PLACE_HOLDER + ext)
 
+    def parse(self, recipe_lines: str) -> list[RecipeParsingError]:
+        errors = []
+        for line_no, line in enumerate(recipe_lines, 1):
+            # Remove comments
+            line = line.partition("#")[0].strip()
+            if not line:
+                continue
+
+            try:
+                # Handle command lines starting with @
+                if line.startswith("@"):
+                    cmd, *args = line.split(maxsplit=1)
+                    args = args[0] if args else ""
+
+                    handler = self.handlers.get(cmd[1:])
+                    if handler is None:
+                        raise ValueError(f"Unknown command '{cmd}'")
+                    if handler.preprocess:
+                        handler(*self.ctx.shell_split(args, pipe_split=False))
+                    else:
+                        handler(args)
+
+                else:
+                    # Expand constants in test generation commands
+                    exe = self.ctx.make_executable(line, Executable)
+                    if self.ctx.scope is None:
+                        raise ValueError(
+                            "Stray generation command (not within any subtask or testset)"
+                        )
+                    self.ctx.scope.add_test(exe)
+
+            except ValueError as e:
+                errors.append(RecipeParsingError(line_no, str(e)))
+        return errors
+
 
 def parse_recipe_data(
     recipe_lines: list[str], is_outputonly: bool = False
-) -> RecipeData:
+) -> RecipeData | list[RecipeParsingError]:
     """
     Parse recipe and return the structured data.
 
@@ -562,40 +616,9 @@ def parse_recipe_data(
     """
 
     parser = RecipeParser()
-
-    for line_num, line in enumerate(recipe_lines, 1):
-        line = line.strip()
-
-        # Remove comments
-        line = line.partition("#")[0].strip()
-        if not line:
-            continue
-
-        try:
-            # Handle command lines starting with @
-            if line.startswith("@"):
-                cmd, *args = line.split(maxsplit=1)
-                args = args[0] if args else ""
-
-                handler = parser.handlers.get(cmd[1:])
-                if handler is None:
-                    raise ValueError(f"Unknown command {cmd}")
-                if handler.preprocess:
-                    handler(*parser.ctx.shell_split(args, pipe_split=False))
-                else:
-                    handler(args)
-
-            else:
-                # Expand constants in test generation commands
-                exe = parser.ctx.make_executable(line, Executable)
-                if parser.ctx.scope is None:
-                    raise ValueError(
-                        "Stray generation command not within any subtask or testset"
-                    )
-                parser.ctx.scope.add_test(exe)
-
-        except ValueError as e:
-            raise ValueError(f"Error on line {line_num}: {e}")
+    error = parser.parse(recipe_lines)
+    if error:
+        return error
 
     # Generate test names after parsing is complete
     if is_outputonly:

--- a/tests/recipes/complex.recipe
+++ b/tests/recipes/complex.recipe
@@ -1,0 +1,42 @@
+@constant MAX_N 200000
+@constant SMALL_N 100
+
+@testset t1
+gen --N=${SMALL_N} seed=1
+gen --N=${SMALL_N} seed=2
+
+@testset t2
+@constant SMALL_N 2000 # overrides in this scope
+gen --N=${SMALL_N} seed=1
+gen --N=${SMALL_N} seed=2
+
+@testset edge_case
+@extra_file NOTE .note
+@description edge cases for N <= ${SMALL_N}
+special --N=1 --note=${NOTE}
+special --N=2 --note=${NOTE}
+gen --N=${SMALL_N} seed=1 | make_extreme
+
+# maybe add these to the top next time
+@global_validation validator --N=${MAX_N}
+@global_validation validator-tester
+
+@subtask s1 20
+@extra_file NOTE .note
+extra --N=5 --note=${NOTE} seed=1
+@description $N \leq ${SMALL_N}$
+@include t1
+@include edge_case
+@validation validator --N=${SMALL_N}
+
+@subtask s2 30
+@description $N \leq 2000$
+@include s1
+@include t2
+@validation validator --N=2000
+
+@subtask s3 50
+@description               No additional constraints
+@include s2
+gen --N=${MAX_N} seed=1
+gen --N=${MAX_N} seed=2

--- a/tests/recipes/cursed.recipe
+++ b/tests/recipes/cursed.recipe
@@ -1,0 +1,4 @@
+@testset "space-> <-space"
+@validation '|' '  ' ''
+'|' | '| |' '"' | "|" '|' "'" 'abcdef # the last quote is unmatched so taken as a whole
+gen '#' | gen '#'

--- a/tests/recipes/diamond.recipe
+++ b/tests/recipes/diamond.recipe
@@ -1,0 +1,13 @@
+@testset A
+gen
+
+@testset B
+@include A
+
+@testset C
+@include A
+
+@subtask D 100
+@include B
+@include C
+@validation val

--- a/tests/recipes/invalid.recipe
+++ b/tests/recipes/invalid.recipe
@@ -1,0 +1,47 @@
+# This file contains multiple tests for invalid recipes.
+# Each test starts with the magic string '#!pytest'
+# To add a test, simply start your test at the bottom.
+#!pytest stray testcase
+gen A
+
+#!pytest same name"
+@subtask A 10
+@testset A
+
+#!pytest bad constant/file definition #1
+@global_validation val ${N}
+
+#!pytest bad constant/file definition #2
+@subtask A 10
+gen
+
+@subtask B 10
+@extra_file test .test
+@validation val ${test}
+@include A
+
+#!pytest bad constant/file definition #3
+@subtask A 10
+@extra_file test .test
+
+@subtask B 10
+@extra_file test .not-test
+@include A
+
+#!pytest invalid include #1
+@subtask A 10
+@include B
+
+#!pytest invalid include #2
+@include A
+
+#!pytest double description
+@subtask A 10
+@description one and two and
+@description three
+
+#!pytest non-global validation
+@validation val
+
+#!pytest invalid command
+@feinberg

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -201,6 +201,33 @@ def complex_recipe_result():
                          [CommandMatcher("validator", "--N=200000"),
                           CommandMatcher("validator-tester")])
 
+def diamond_recipe_result():
+    a = (TestsetMatcher(name="A", index=1, desc=None)
+         .val("val")
+         .testcase("1_A_1", gen=["gen"], val=[["val"]]))
+
+    b = (TestsetMatcher(name="B", index=2, desc=None)
+         .val("val")
+         .depend(a))
+
+    c = (TestsetMatcher(name="C", index=3, desc=None)
+         .val("val")
+         .depend(a))
+
+    d = (SubtaskMatcher(name="D", index=None, desc=None, score=100)
+         .val("val")
+         .depend(a, b, c))
+
+    return RecipeMatcher([a, b, c, d], [])
+
+
+def cursed_recipe_result():
+    a = (TestsetMatcher(name="space-> <-space", index=1, desc=None)
+         .val("|", "  ", "")
+         .testcase("1_space-> <-space_1", gen=[["|"], ["| |", '"'], ["|", "|", "'", "'abcdef"]])
+         .testcase("1_space-> <-space_2", gen=[["gen", '#'], ["gen", '#']]))
+
+    return RecipeMatcher([a], [])
 # fmt: on
 
 
@@ -208,6 +235,8 @@ def complex_recipe_result():
     "recipe_path, expected",
     [
         ("recipes/complex.recipe", complex_recipe_result),
+        ("recipes/diamond.recipe", diamond_recipe_result),
+        ("recipes/cursed.recipe", cursed_recipe_result),
     ],
 )
 def test_recipe(
@@ -218,3 +247,42 @@ def test_recipe(
     with open(problem_dir, "r") as f:
         recipe = parse_recipe_data(f.readlines())
     expected().match(recipe)
+
+
+def parse_invalid_recipes():
+
+    path = pathlib.Path(__file__).parent.resolve() / "recipes/invalid.recipe"
+    lines = path.read_text().splitlines(keepends=True)
+
+    recipes = {}
+    current_name, current_lines = None, []
+
+    for line in lines:
+        if line.startswith("#!pytest"):
+            if current_name is not None:
+                recipes[current_name] = current_lines
+            parts = line.split(maxsplit=1)
+            if len(parts) == 1:
+                raise ValueError(f"invalid.recipe: test has no name: {line!r}")
+            current_name = parts[1].strip()
+            if current_name in recipes:
+                raise ValueError(
+                    f"invalid.recipe: duplicate test name: {current_name!r}"
+                )
+            current_lines = []
+        else:
+            current_lines.append(line)
+
+    if current_name is not None:
+        recipes[current_name] = current_lines
+    return recipes
+
+
+@pytest.mark.parametrize(
+    "recipe_content",
+    [pytest.param(v, id=k) for k, v in parse_invalid_recipes().items()],
+)
+def test_failing_recipe(recipe_content: list[str]):
+    recipe = parse_recipe_data(recipe_content)
+    print(recipe)
+    assert not isinstance(recipe, rp.RecipeData)

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -1,0 +1,220 @@
+import pathlib
+import pytest
+from typing import Callable
+from dataclasses import dataclass
+
+import internal.recipe_parser as rp
+from internal.recipe_parser import parse_recipe_data
+
+
+class CommandMatcher:
+    def __init__(self, *args):
+        self.cmds: list[list[str]]
+        if len(args) == 0:
+            self.cmds = [[]]
+        elif all(
+            isinstance(arg, list) and all(isinstance(x, str) for x in arg)
+            for arg in args
+        ):
+            self.cmds = list(args)
+        elif all(isinstance(arg, str) for arg in args):
+            self.cmds = [list(args)]
+        elif len(args) == 1:
+            self.cmds = args[0]
+        else:
+            raise ValueError(f"Cannot construct CommandMatcher from {args}")
+
+    def match(self, rhs):
+        assert isinstance(rhs, rp.Command)
+        assert self.cmds == rhs.commands
+
+    @classmethod
+    def list_match(cls, expect: list["CommandMatcher"], actual: list[rp.Command]):
+        assert len(expect) == len(actual)
+        expect.sort(key=lambda e: e.cmds)
+        actual.sort(key=lambda e: e.commands)
+        for expect_exe, actual_exe in zip(expect, actual):
+            expect_exe.match(actual_exe)
+
+
+class TestcaseMatcher:
+    __test__ = False
+
+    def __init__(
+        self, name: str, gen: list[list[str]] | list[str], val: list[list[str]] | None
+    ):
+        self.name = name
+        self.gen = CommandMatcher(gen)
+        self.val = [CommandMatcher([v]) for v in val] if val else None
+
+    def match(self, rhs):
+        assert isinstance(rhs, rp.Testcase)
+        assert self.name == rhs.name
+        self.gen.match(rhs.execute)
+        if self.val is not None:
+            CommandMatcher.list_match(self.val, rhs.validation)
+
+    @classmethod
+    def list_match(cls, expect: list["TestcaseMatcher"], actual: list[rp.Testcase]):
+        assert len(expect) == len(actual)
+        expect.sort(key=lambda e: e.name)
+        actual.sort(key=lambda e: e.name)
+        for expect_exe, actual_exe in zip(expect, actual):
+            expect_exe.match(actual_exe)
+
+
+class TestsetMatcher:
+    __test__ = False
+
+    def __init__(self, name: str, index: int | None, desc: str | None):
+        self.name = name
+        self.index = index
+        self.desc = desc
+        self.validation: list[CommandMatcher] = []
+        self.testcases: list[TestcaseMatcher] = []
+        self.dependency: list["TestsetMatcher"] = []
+        self.extra_file: list[str] = []
+
+        self._already_matched: rp.Testset | None = None
+
+    def val(self, *args):
+        self.validation.append(CommandMatcher(*args))
+        return self
+
+    def testcase(
+        self,
+        name: str,
+        gen: list[list[str]] | list[str],
+        val: list[list[str]] | None = None,
+    ):
+        self.testcases.append(TestcaseMatcher(name=name, gen=gen, val=val))
+        return self
+
+    def depend(self, *testsets: "TestsetMatcher"):
+        for ts in testsets:
+            self.dependency.append(ts)
+        return self
+
+    def extra(self, file: str):
+        self.extra_file.append(file)
+        return self
+
+    def match(self, rhs):
+        assert isinstance(rhs, rp.Testset)
+        assert self.name == rhs.name
+        assert self.index == rhs.index
+        assert self.desc == rhs.description
+        CommandMatcher.list_match(self.validation, rhs.validation)
+        TestcaseMatcher.list_match(self.testcases, rhs.testcases)
+        TestsetMatcher.list_match(self.dependency, rhs.dependency)
+        assert set(self.extra_file) == rhs.extra_file
+
+        if self._already_matched is None:
+            self._already_matched = rhs
+        assert self._already_matched is rhs
+
+    @classmethod
+    def list_match(cls, expect: list["TestsetMatcher"], actual: list[rp.Testset]):
+        assert len(expect) == len(actual)
+        expect.sort(key=lambda e: e.name)
+        actual.sort(key=lambda e: e.name)
+        for expect_exe, actual_exe in zip(expect, actual):
+            expect_exe.match(actual_exe)
+
+
+class SubtaskMatcher(TestsetMatcher):
+    def __init__(self, name: str, index: int | None, desc: str | None, score: float):
+        super().__init__(name, index, desc)
+        self.score = score
+
+    def match(self, rhs):
+        assert isinstance(rhs, rp.Subtask)
+        super().match(rhs)
+        assert self.score == rhs.score
+
+
+@dataclass(frozen=True)
+class RecipeMatcher:
+    testsets: list[TestsetMatcher]
+    global_val: list[CommandMatcher]
+
+    def match(self, rhs):
+        assert isinstance(rhs, rp.RecipeData)
+        TestsetMatcher.list_match(self.testsets, list(rhs.testsets.values()))
+        TestsetMatcher.list_match(
+            [s for s in self.testsets if isinstance(s, SubtaskMatcher)],
+            [s for s in rhs.testsets.values() if isinstance(s, rp.Subtask)],
+        )
+        CommandMatcher.list_match(self.global_val, rhs.global_validation)
+
+
+# fmt: off
+def complex_recipe_result():
+    t1 = (TestsetMatcher(name="t1", index=1, desc=None)
+          .val("validator", "--N=100")
+          .val("validator", "--N=2000")
+          .val("validator", "--N=200000")
+          .val("validator-tester")
+          .testcase("1_t1_1", gen=["gen", "--N=100", "seed=1"])
+          .testcase("1_t1_2", gen=["gen", "--N=100", "seed=2"]))
+
+    t2 = (TestsetMatcher(name="t2", index=2, desc=None)
+          .val("validator", "--N=2000")
+          .val("validator", "--N=200000")
+          .val("validator-tester")
+          .testcase("2_t2_1", gen=["gen", "--N=2000", "seed=1"])
+          .testcase("2_t2_2", gen=["gen", "--N=2000", "seed=2"]))
+
+    edge = (TestsetMatcher(name="edge_case", index=3, desc="edge cases for N <= 100")
+            .val("validator", "--N=100")
+            .val("validator", "--N=2000")
+            .val("validator", "--N=200000")
+            .val("validator-tester")
+            .testcase("3_edge_case_1", gen=["special", "--N=1", "--note=3_edge_case_1.note"])
+            .testcase("3_edge_case_2", gen=["special", "--N=2", "--note=3_edge_case_2.note"])
+            .testcase("3_edge_case_3", gen=[["gen", "--N=100", "seed=1"], ["make_extreme"]])
+            .extra(".note"))
+
+    s1 = (SubtaskMatcher(name="s1", index=4, desc="$N \\leq 100$", score=20)
+          .val("validator", "--N=100")
+          .val("validator", "--N=2000")
+          .val("validator", "--N=200000")
+          .val("validator-tester")
+          .testcase("4_s1_1", gen=["extra", "--N=5", "--note=4_s1_1.note", "seed=1"])
+          .depend(t1, edge)
+          .extra(".note"))
+
+    s2 = (SubtaskMatcher(name="s2", index=None, desc="$N \\leq 2000$", score=30)
+          .val("validator", "--N=2000")
+          .val("validator", "--N=200000")
+          .val("validator-tester")
+          .depend(t1, t2, edge, s1))
+
+    s3 = (SubtaskMatcher(name="s3", index=5, desc="No additional constraints", score=50)
+          .val("validator", "--N=200000")
+          .val("validator-tester")
+          .testcase("5_s3_1", gen=["gen", "--N=200000", "seed=1"])
+          .testcase("5_s3_2", gen=["gen", "--N=200000", "seed=2"])
+          .depend(t1, t2, edge, s1, s2))
+
+    return RecipeMatcher([t1, t2, edge, s1, s2, s3],
+                         [CommandMatcher("validator", "--N=200000"),
+                          CommandMatcher("validator-tester")])
+
+# fmt: on
+
+
+@pytest.mark.parametrize(
+    "recipe_path, expected",
+    [
+        ("recipes/complex.recipe", complex_recipe_result),
+    ],
+)
+def test_recipe(
+    recipe_path: str,
+    expected: Callable[[], RecipeMatcher],
+):
+    problem_dir = pathlib.Path(__file__).parent.resolve() / recipe_path
+    with open(problem_dir, "r") as f:
+        recipe = parse_recipe_data(f.readlines())
+    expected().match(recipe)


### PR DESCRIPTION
This PR improves the recipe parsing part.

The following changes/fixes are expected:
- [ ] Properly define the recipe file syntax and properly parse the file.
- [ ] Support quotations
   - In particular, the pipe `|` and comment `#` are both allowed to be contained within the quotation marks to act as part of the generation command.
- [ ] Fix constant scoping
   - Constant should now be properly scoped inside subtasks and testsets if not defined at the top level.
- [ ] Fix extra file related issues
   - Extra file used to cause several issues or ambiguity when generating the testcases (examples and details TBA).
- [ ] When recipe fails, report more errors at once.
- [ ] Support custom testcase naming convention
- [ ] Add tests to the recipe parser.
   - Also migrates old recipe in `recipe_parser.py` into a test.
- [ ] Add an experimental VSCode syntax highlighter extension.
   - Should we also add that for other editors/IDE as well, for example, vim?