### PR TITLE
feat: add compile command

### DIFF
--- a/internal/commands/__init__.py
+++ b/internal/commands/__init__.py
@@ -1,3 +1,4 @@
+from .compile import command_compile
 from .gen import command_gen
 from .invoke import command_invoke
 from .clean import command_clean
@@ -6,6 +7,7 @@ from .make_public import command_make_public
 from .verify import command_verify
 
 __all__ = [
+    "command_compile",
     "command_gen",
     "command_invoke",
     "command_clean",

--- a/internal/commands/compile.py
+++ b/internal/commands/compile.py
@@ -89,7 +89,7 @@ def compile_single(
     formatter.print_compile_result(result, name=source_name)
 
     if result.verdict is CompilationOutcome.SUCCESS and result.produced_file is None:
-        raise FileNotFoundError("Compilation did not produce source executable")
+        raise FileNotFoundError("Compilation did not produce executable")
 
     result.dump_to_logs(context.log_directory, source_path.stem)
     return summary

--- a/internal/commands/compile.py
+++ b/internal/commands/compile.py
@@ -1,0 +1,183 @@
+import os
+import pathlib
+from dataclasses import dataclass
+
+from internal.formatting import Formatter
+from internal.context import (
+    AnswerGenerationType,
+    TMTContext,
+    SandboxDirectory,
+)
+from internal.compilation import recognize_language
+from internal.outcomes import (
+    CompilationOutcome,
+    CompilationResult,
+)
+from internal.compilation.makefile import make_compile_target
+
+from internal.steps.generation import GenerationStep
+from internal.steps.utils import CompilationJob, CompilationSlot
+from internal.steps.validation import ValidationStep
+from internal.steps.solution import get_solution_step_type
+from internal.steps.checker import CheckerStep, get_checker_step_type
+
+
+@dataclass
+class CommandCompileAllSummary:
+    compilation_result: dict[CompilationSlot, CompilationResult]
+
+    def __bool__(self) -> bool:
+        def is_compilation_error(cresult: CompilationResult | None):
+            return cresult is not None and not cresult
+
+        return not any(map(is_compilation_error, self.compilation_result.values()))
+
+
+@dataclass
+class CommandCompileSingleSummary:
+    compilation_result: CompilationResult | None = None
+    source: str | None = None
+
+    def __bool__(self) -> bool:
+        return bool(self.compilation_result)
+
+
+def compile_single(
+    *,
+    formatter: Formatter,
+    context: TMTContext,
+    source: str,
+) -> CommandCompileSingleSummary:
+
+    summary = CommandCompileSingleSummary()
+    context.set_log_directory(context.path.logs)
+
+    source_path = pathlib.Path(source).expanduser().resolve()
+    source_name = source_path.name
+    source_directory = str(source_path.parent)
+
+    def compile_fail(reason: str) -> CommandCompileSingleSummary:
+        result = CompilationResult(
+            verdict=CompilationOutcome.FAILED,
+            exit_status=-1,
+            standard_error=reason,
+        )
+        summary.compilation_result = result
+        summary.source = source_name
+        formatter.print_compile_result(result, name=source_name)
+        result.dump_to_logs(context.log_directory, source_path.stem)
+        return summary
+
+    if not source_path.exists() or not source_path.is_file():
+        return compile_fail(f"Source file {source_name} is not a file.")
+
+    if recognize_language([str(source_path)], context) is None:
+        return compile_fail(
+            f"Source file {source_name} is not recognized by any language."
+        )
+
+    formatter.print(f"{source_name.ljust(10)}  compile ")
+    result = make_compile_target(
+        context=context,
+        directory=source_directory,
+        sources=[source_name],
+        target=source_path.stem,
+        executable_stack_size_mib=context.config.trusted_step_memory_limit_mib,
+    )
+    summary.compilation_result = result
+    summary.source = source_name
+    formatter.print_compile_result(result, name=source_name)
+
+    if (
+        result.verdict is CompilationOutcome.SUCCESS
+        and result.produced_file is None
+    ):
+        raise FileNotFoundError("Compilation did not produce source executable")
+
+    result.dump_to_logs(context.log_directory, source_path.stem)
+    return summary
+
+
+def compile_all(
+    *,
+    formatter: Formatter,
+    context: TMTContext,
+) -> CommandCompileAllSummary:
+    """Generate test cases in the given directory."""
+    context.set_log_directory(context.path.logs_generation)
+    summary = CommandCompileAllSummary(compilation_result={})
+
+    # TODO when multiprocess generation is used, reflect this sandbox usage
+    sandbox = SandboxDirectory(context.path.default_sandbox)
+    sandbox.create()
+
+    context.path.clean_logs()
+    os.makedirs(context.path.logs)
+    os.makedirs(context.path.logs_generation, exist_ok=True)
+
+    # Init all steps
+    generation_step = GenerationStep(context=context, sandbox=sandbox)
+    validation_step = ValidationStep(context=context, sandbox=sandbox)
+
+    assert context.config.answer_generation.type is AnswerGenerationType.SOLUTION
+    solution_step_type = get_solution_step_type(
+        problem_type=context.config.problem_type,
+        judge_convention=context.config.judge_convention,
+    )
+    solution_step = solution_step_type(
+        context=context,
+        sandbox=sandbox,
+        is_generation=True,
+        submission_files=[
+            os.path.join(
+                context.path.solutions, context.config.answer_generation.filename
+            )
+        ],
+    )
+
+    checker_step_type = get_checker_step_type(
+        problem_type=context.config.problem_type,
+        judge_convention=context.config.judge_convention,
+    )
+    checker_step: CheckerStep | None = None
+    if checker_step_type is not None:
+        checker_step = checker_step_type(
+            context=context, sandbox=sandbox, is_generation=True
+        )
+        checker_step.check_unused_checker(formatter)
+
+        # During generation, if the default checker is used then it is never meaningful to run it because it always succeed
+        if checker_step.use_default_checker:
+            checker_step = None
+
+    # Compile steps
+    def compilation_jobs():
+        yield CompilationJob(CompilationSlot.GENERATOR, generation_step.compile, "")
+        yield CompilationJob(CompilationSlot.VALIDATOR, validation_step.compile, "")
+        yield from solution_step.compilation_jobs()
+        if checker_step is not None:
+            yield CompilationJob(
+                CompilationSlot.CHECKER, checker_step.compile, checker_step.checker_name
+            )
+
+    for job in compilation_jobs():
+        formatter.print(f"{job.slot.value.ljust(10)}  compile ")
+        result = job.compile_fn()
+        summary.compilation_result[job.slot] = result
+        formatter.print_compile_result(result, name=job.display_file)
+        if not result:
+            return summary
+
+    return summary
+
+
+def command_compile(
+    *,
+    formatter: Formatter,
+    context: TMTContext,
+    source: str | None,
+) -> CommandCompileAllSummary | CommandCompileSingleSummary:
+    if source is None:
+        return compile_all(formatter=formatter, context=context)
+
+    return compile_single(formatter=formatter, context=context, source=source)

--- a/internal/commands/compile.py
+++ b/internal/commands/compile.py
@@ -18,7 +18,7 @@ from internal.compilation.makefile import make_compile_target
 from internal.steps.generation import GenerationStep
 from internal.steps.utils import CompilationJob, CompilationSlot
 from internal.steps.validation import ValidationStep
-from internal.steps.solution import get_solution_step_type
+from internal.steps.solution import SolutionStep, get_solution_step_type
 from internal.steps.checker import CheckerStep, get_checker_step_type
 
 
@@ -88,10 +88,7 @@ def compile_single(
     summary.source = source_name
     formatter.print_compile_result(result, name=source_name)
 
-    if (
-        result.verdict is CompilationOutcome.SUCCESS
-        and result.produced_file is None
-    ):
+    if result.verdict is CompilationOutcome.SUCCESS and result.produced_file is None:
         raise FileNotFoundError("Compilation did not produce source executable")
 
     result.dump_to_logs(context.log_directory, source_path.stem)
@@ -171,6 +168,45 @@ def compile_all(
     return summary
 
 
+def compile_solution_source(
+    *,
+    formatter: Formatter,
+    context: TMTContext,
+    source_path: pathlib.Path,
+) -> CommandCompileSingleSummary:
+    summary = CommandCompileSingleSummary()
+    context.set_log_directory(context.path.logs)
+
+    sandbox = SandboxDirectory(context.path.default_sandbox)
+    sandbox.create()
+
+    solution_step_type = get_solution_step_type(
+        problem_type=context.config.problem_type,
+        judge_convention=context.config.judge_convention,
+    )
+    solution_step: SolutionStep = solution_step_type(
+        context=context,
+        sandbox=sandbox,
+        is_generation=False,
+        submission_files=[str(source_path)],
+    )
+
+    for job in solution_step.compilation_jobs():
+        formatter.print(f"{job.slot.value.ljust(10)}  compile ")
+        result = job.compile_fn()
+        summary.compilation_result = result
+        summary.source = source_path.name
+        formatter.print_compile_result(result, name=job.display_file)
+        if not result:
+            return summary
+
+    return summary
+
+
+def _is_under(path: pathlib.Path, root: str) -> bool:
+    return path.is_relative_to(pathlib.Path(root))
+
+
 def command_compile(
     *,
     formatter: Formatter,
@@ -180,4 +216,30 @@ def command_compile(
     if source is None:
         return compile_all(formatter=formatter, context=context)
 
-    return compile_single(formatter=formatter, context=context, source=source)
+    source_path = pathlib.Path(source).expanduser().resolve()
+    if _is_under(source_path, context.path.solutions):
+        return compile_solution_source(
+            formatter=formatter,
+            context=context,
+            source_path=source_path,
+        )
+    if _is_under(source_path, context.path.validator):
+        return compile_single(formatter=formatter, context=context, source=source)
+    if _is_under(source_path, context.path.generator):
+        return compile_single(formatter=formatter, context=context, source=source)
+    if _is_under(source_path, context.path.checker):
+        return compile_single(formatter=formatter, context=context, source=source)
+
+    result = CompilationResult(
+        verdict=CompilationOutcome.FAILED,
+        exit_status=-1,
+        standard_error=(
+            f"Source file {source_path.name} is not found under solutions, "
+            "validator, generator, or checker."
+        ),
+    )
+    formatter.print_compile_result(result, name=source_path.name)
+    return CommandCompileSingleSummary(
+        compilation_result=result,
+        source=source_path.name,
+    )

--- a/internal/commands/compile.py
+++ b/internal/commands/compile.py
@@ -213,6 +213,13 @@ def command_compile(
     context: TMTContext,
     source: str | None,
 ) -> CommandCompileAllSummary | CommandCompileSingleSummary:
+    """Compile all problem components or a single source file.
+
+    With no source, compile all components required by the problem. When a
+    source is provided, compile it using the appropriate pipeline for its
+    location: solutions use the solution pipeline, while generators,
+    validators, and checkers are compiled directly.
+    """
     if source is None:
         return compile_all(formatter=formatter, context=context)
 

--- a/internal/commands/compile.py
+++ b/internal/commands/compile.py
@@ -50,7 +50,7 @@ def compile_single(
 ) -> CommandCompileSingleSummary:
 
     summary = CommandCompileSingleSummary()
-    context.set_log_directory(context.path.logs)
+    context.set_log_directory(context.path.logs_compile_single)
 
     source_path = pathlib.Path(source).expanduser().resolve()
     source_name = source_path.name
@@ -175,7 +175,7 @@ def compile_solution_source(
     source_path: pathlib.Path,
 ) -> CommandCompileSingleSummary:
     summary = CommandCompileSingleSummary()
-    context.set_log_directory(context.path.logs)
+    context.set_log_directory(context.path.logs_compile_single)
 
     sandbox = SandboxDirectory(context.path.default_sandbox)
     sandbox.create()

--- a/internal/context/paths.py
+++ b/internal/context/paths.py
@@ -80,6 +80,7 @@ class ProblemDirectoryHelper:
     logs = _problem_path_property("logs")
     logs_generation = _extend_path_property(logs, "generation")
     logs_invocation = _extend_path_property(logs, "invocation")
+    logs_compile_single = _extend_path_property(logs, "compile-single")
 
     # Important files
     problem_yaml = _problem_path_property("problem.yaml")

--- a/tests/test_compile_command.py
+++ b/tests/test_compile_command.py
@@ -12,16 +12,14 @@ from internal.outcomes import CompilationOutcome
 from internal.steps.utils import CompilationSlot
 
 
-def _make_context() -> TMTContext:
+def _make_context(problem_relpath: str) -> TMTContext:
     script_dir = pathlib.Path(__file__).parent.parent.resolve()
-    problem_dir = (
-        pathlib.Path(__file__).parent / "problems" / "batch" / "icpc-generator"
-    )
+    problem_dir = pathlib.Path(__file__).parent / "problems" / problem_relpath
     return TMTContext(str(problem_dir), str(script_dir))
 
 
 def test_compile_single_uses_source_directory():
-    context = _make_context()
+    context = _make_context("batch/icpc-generator")
     source_file = pathlib.Path(context.path.generator) / "print.cpp"
 
     try:
@@ -45,7 +43,7 @@ def test_compile_single_uses_source_directory():
 
 
 def test_compile_without_source_uses_compile_all():
-    context = _make_context()
+    context = _make_context("batch/cms-verdict")
 
     try:
         result = command_compile(
@@ -58,5 +56,26 @@ def test_compile_without_source_uses_compile_all():
         assert CompilationSlot.GENERATOR in result.compilation_result
         assert CompilationSlot.VALIDATOR in result.compilation_result
         assert CompilationSlot.SOLUTION in result.compilation_result
+    finally:
+        command_clean(formatter=EmptyFormatter(), context=context, skip_confirm=True)
+
+
+def test_compile_solution_with_grader_headers():
+    context = _make_context("communication/2-proc-grader-fifo")
+    source_file = pathlib.Path(context.path.solutions) / "model-solution.cpp"
+
+    try:
+        summary = command_compile(
+            formatter=EmptyFormatter(),
+            context=context,
+            source=str(source_file),
+        )
+
+        assert isinstance(summary, CommandCompileSingleSummary)
+        assert summary.compilation_result is not None
+        assert summary.compilation_result.verdict is CompilationOutcome.SUCCESS
+        assert summary.source == "model-solution.cpp"
+        assert summary.compilation_result.produced_file is not None
+        assert pathlib.Path(summary.compilation_result.produced_file).exists()
     finally:
         command_clean(formatter=EmptyFormatter(), context=context, skip_confirm=True)

--- a/tests/test_compile_command.py
+++ b/tests/test_compile_command.py
@@ -1,0 +1,62 @@
+import pathlib
+
+from internal.commands.compile import (
+    CommandCompileAllSummary,
+    CommandCompileSingleSummary,
+    command_compile,
+)
+from internal.commands.clean import command_clean
+from internal.context import TMTContext
+from internal.formatting.empty import EmptyFormatter
+from internal.outcomes import CompilationOutcome
+from internal.steps.utils import CompilationSlot
+
+
+def _make_context() -> TMTContext:
+    script_dir = pathlib.Path(__file__).parent.parent.resolve()
+    problem_dir = (
+        pathlib.Path(__file__).parent / "problems" / "batch" / "icpc-generator"
+    )
+    return TMTContext(str(problem_dir), str(script_dir))
+
+
+def test_compile_single_uses_source_directory():
+    context = _make_context()
+    source_file = pathlib.Path(context.path.generator) / "print.cpp"
+
+    try:
+        summary = command_compile(
+            formatter=EmptyFormatter(),
+            context=context,
+            source=str(source_file),
+        )
+
+        assert isinstance(summary, CommandCompileSingleSummary)
+        assert summary.compilation_result is not None
+        assert summary.compilation_result.verdict is CompilationOutcome.SUCCESS
+        assert summary.source == "print.cpp"
+        assert summary.compilation_result.produced_file is not None
+        assert pathlib.Path(summary.compilation_result.produced_file).exists()
+        assert summary.compilation_result.produced_file.startswith(
+            str(source_file.parent)
+        )
+    finally:
+        command_clean(formatter=EmptyFormatter(), context=context, skip_confirm=True)
+
+
+def test_compile_without_source_uses_compile_all():
+    context = _make_context()
+
+    try:
+        result = command_compile(
+            formatter=EmptyFormatter(),
+            context=context,
+            source=None,
+        )
+
+        assert isinstance(result, CommandCompileAllSummary)
+        assert CompilationSlot.GENERATOR in result.compilation_result
+        assert CompilationSlot.VALIDATOR in result.compilation_result
+        assert CompilationSlot.SOLUTION in result.compilation_result
+    finally:
+        command_clean(formatter=EmptyFormatter(), context=context, skip_confirm=True)

--- a/tmt.py
+++ b/tmt.py
@@ -4,6 +4,7 @@ import pathlib
 from internal.commands.verify import command_verify_config, command_verify_verdicts
 from internal.context import TMTContext, find_problem_dir
 from internal.commands import (
+    command_compile,
     command_gen,
     command_invoke,
     command_clean,
@@ -28,6 +29,9 @@ def main():
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     # parser_init = subparsers.add_parser("init", help="Init a TMT problem directory.")
+
+    parser_compile = subparsers.add_parser("compile", help="Compile source codes.")
+    parser_compile.add_argument("source", nargs="?", help="Specify file to compile")
 
     parser_gen = subparsers.add_parser("gen", help="Generate testcases.")
     parser_gen.add_argument(
@@ -92,6 +96,14 @@ def main():
             "Warning: In problem.yaml, tmt_version is set to 'latest' in this problem. You should never use 'latest' in non-unit-test problem repositories.",
             formatter.ANSI_RESET,
         )
+
+    if args.command == "compile":
+        cmd_ret = command_compile(
+            formatter=formatter,
+            context=context,
+            source=args.source,
+        )
+        return bool(cmd_ret)
 
     if args.command == "gen":
         cmd_ret = command_gen(


### PR DESCRIPTION
Add a command to just compile: `tmt compile [source]`

If we don't provide any argument, like
```bash
tmt compile
```
then it will compile all source files needed by the generation step.

Or, we can provide a path and it'll only compile that file:
```bash
tmt compile generator/print.cpp
```
